### PR TITLE
Add schema-based validators with default and custom error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ migrate_working_dir/
 *.ipr
 *.iws
 .idea/
+/lib/generated/
 
 # The .vscode folder contains launch configuration and tasks you configure in
 # VS Code which you may wish to be included in version control, so this line

--- a/example/lib/examples/l18n_custom_bundle_example.dart
+++ b/example/lib/examples/l18n_custom_bundle_example.dart
@@ -1,0 +1,133 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:flutter/material.dart';
+
+final _schema = {
+  "title": "Sign up",
+  "required": ["email"],
+  "properties": {
+    "firstName": {"type": "string", "title": "Full Name", "minLength": 5},
+    "email": {
+      "type": "string",
+      "title": "Email",
+      "pattern": r"^[^\s@]+@[^\s@]+\.[^\s@]+$",
+    },
+    "age": {"type": "integer", "title": "Age", "minimum": 18},
+  },
+};
+
+const languages = [
+  'en',
+  'es',
+  'de',
+  'it',
+  'pt',
+  'fr',
+  'nl',
+  'ja',
+  'zh',
+  'ru',
+  'pl',
+];
+
+/// This is a custom bundle. It can modify the built-in message to return
+/// a different text. This could be beneficial for example if you are using
+/// a package for translations different tha Intl and you want to show your
+/// own translations.
+class MyCustomBundle extends DjsfMessageBundle {
+  @override
+  String equals(allowed) {
+    return "My custom equals message $allowed";
+  }
+
+  @override
+  String max(num limit) {
+    return "My custom max message $limit";
+  }
+
+  @override
+  String maxLength(int limit) {
+    return "My custom maxLength message $limit";
+  }
+
+  @override
+  String min(num limit) {
+    return "My custom min message $limit";
+  }
+
+  @override
+  String minLength(int limit) {
+    return "My custom minLength message $limit";
+  }
+
+  @override
+  String pattern() {
+    return "My custom pattern message";
+  }
+
+  @override
+  String required() {
+    return "My custom required message";
+  }
+}
+
+class L18nCustomBundlesExample extends StatefulWidget {
+  static const route = '/custom_l18n';
+
+  const L18nCustomBundlesExample({super.key});
+
+  @override
+  State<L18nCustomBundlesExample> createState() =>
+      _L18nCustomBundlesExampleState();
+}
+
+class _L18nCustomBundlesExampleState extends State<L18nCustomBundlesExample> {
+  String language = 'en';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('DJSF Custom Internationalization Example'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                height: kToolbarHeight,
+                child: ListView.builder(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: languages.length,
+                  shrinkWrap: true,
+                  itemBuilder:
+                      (context, i) => TextButton(
+                        onPressed:
+                            language != languages[i]
+                                ? () {
+                                  setState(() {
+                                    language = languages[i];
+                                  });
+                                }
+                                : null,
+                        child: Text(languages[i].toUpperCase()),
+                      ),
+                ),
+              ),
+              Divider(height: 12),
+              Flexible(
+                child: DjsfForm(
+                  schema: _schema,
+
+                  /// Here is set the custom translations bundle.
+                  messagesBundle: MyCustomBundle(),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/examples/l18n_messages_example.dart
+++ b/example/lib/examples/l18n_messages_example.dart
@@ -1,0 +1,82 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:flutter/material.dart';
+
+final _schema = {
+  "title": "Sign up",
+  "required": ["email"],
+  "properties": {
+    "firstName": {"type": "string", "title": "Full Name", "minLength": 5},
+    "email": {
+      "type": "string",
+      "title": "Email",
+      "pattern": r"^[^\s@]+@[^\s@]+\.[^\s@]+$",
+    },
+    "age": {"type": "integer", "title": "Age", "minimum": 18},
+  },
+};
+
+const languages = [
+  'en',
+  'es',
+  'de',
+  'it',
+  'pt',
+  'fr',
+  'nl',
+  'ja',
+  'zh',
+  'ru',
+  'pl',
+];
+
+class L18nMessagesExample extends StatefulWidget {
+  static const route = '/l18n';
+
+  const L18nMessagesExample({super.key});
+
+  @override
+  State<L18nMessagesExample> createState() => _L18nMessagesExampleState();
+}
+
+class _L18nMessagesExampleState extends State<L18nMessagesExample> {
+  String language = 'en';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('DJSF Internationalization Example')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                height: kToolbarHeight,
+                child: ListView.builder(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: languages.length,
+                  shrinkWrap: true,
+                  itemBuilder:
+                      (context, i) => TextButton(
+                        onPressed:
+                            language != languages[i]
+                                ? () {
+                                  setState(() {
+                                    language = languages[i];
+                                  });
+                                }
+                                : null,
+                        child: Text(languages[i].toUpperCase()),
+                      ),
+                ),
+              ),
+              Divider(height: 12),
+              Flexible(child: DjsfForm(schema: _schema, locale: language)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/examples/validation_messages_example.dart
+++ b/example/lib/examples/validation_messages_example.dart
@@ -1,7 +1,7 @@
 import 'package:dart_json_schema_form/dart_json_schema_form.dart';
 import 'package:flutter/material.dart';
 
-final _schema = {
+final validationMessagesSchema = {
   "title": "Sign up",
   "required": ["email"],
   "properties": {
@@ -23,11 +23,11 @@ class ValidationMessagesExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('DJSF Very Simple Example')),
+      appBar: AppBar(title: const Text('DJSF Validation messages')),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: DjsfForm(
-          schema: _schema,
+          schema: validationMessagesSchema,
           transformErrors: (errors) {
             // Mutate messages conditionally (just like RJSF)
             return errors.map((e) {

--- a/example/lib/examples/validation_messages_example.dart
+++ b/example/lib/examples/validation_messages_example.dart
@@ -1,0 +1,49 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:flutter/material.dart';
+
+final _schema = {
+  "title": "Sign up",
+  "required": ["email"],
+  "properties": {
+    "firstName": {"type": "string", "title": "Full Name", "minLength": 5},
+    "email": {
+      "type": "string",
+      "title": "Email",
+      "pattern": r"^[^\s@]+@[^\s@]+\.[^\s@]+$",
+    },
+    "age": {"type": "integer", "title": "Age", "minimum": 18},
+  },
+};
+
+class ValidationMessagesExample extends StatelessWidget {
+  static const route = '/validation';
+
+  const ValidationMessagesExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('DJSF Very Simple Example')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: DjsfForm(
+          schema: _schema,
+          transformErrors: (errors) {
+            // Mutate messages conditionally (just like RJSF)
+            return errors.map((e) {
+              if (e.name == 'pattern' && e.property == '.email') {
+                e.message =
+                    'Custom message: Please enter a valid email address';
+              }
+              if (e.name == 'min' && e.property == '.age') {
+                final limit = e.params?['limit'];
+                e.message = 'Custom message: Must be at least $limit years old';
+              }
+              return e;
+            }).toList();
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'examples/validation_messages_example.dart';
 import 'examples/very_simple_form_example.dart';
 
 void main() {
@@ -18,6 +19,8 @@ class MyApp extends StatelessWidget {
       home: const _HomePage(title: _appTitle),
       routes: {
         VerySimpleFormExample.route: (_) => const VerySimpleFormExample(),
+        ValidationMessagesExample.route:
+            (_) => const ValidationMessagesExample(),
       },
     );
   }
@@ -43,6 +46,16 @@ class _HomePage extends StatelessWidget {
                 () => Navigator.of(
                   context,
                 ).pushNamed(VerySimpleFormExample.route),
+          ),
+          const Divider(),
+          ListTile(
+            title: const Text('Validation messages'),
+            subtitle: const Text('Form validation with custom messages'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap:
+                () => Navigator.of(
+                  context,
+                ).pushNamed(ValidationMessagesExample.route),
           ),
           const Divider(),
           // Here will come more examples.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,8 @@
+import 'package:dart_json_schema_form/generated/l10n.dart' as djsf_l10n;
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'examples/l18n_custom_bundle_example.dart';
+import 'examples/l18n_messages_example.dart';
 import 'examples/validation_messages_example.dart';
 import 'examples/very_simple_form_example.dart';
 
@@ -17,10 +21,18 @@ class MyApp extends StatelessWidget {
       title: _appTitle,
       theme: ThemeData(useMaterial3: true),
       home: const _HomePage(title: _appTitle),
+      localizationsDelegates: const [
+        djsf_l10n.S.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
       routes: {
         VerySimpleFormExample.route: (_) => const VerySimpleFormExample(),
         ValidationMessagesExample.route:
             (_) => const ValidationMessagesExample(),
+        L18nMessagesExample.route: (_) => const L18nMessagesExample(),
+        L18nCustomBundlesExample.route: (_) => const L18nCustomBundlesExample(),
       },
     );
   }
@@ -56,6 +68,29 @@ class _HomePage extends StatelessWidget {
                 () => Navigator.of(
                   context,
                 ).pushNamed(ValidationMessagesExample.route),
+          ),
+          const Divider(),
+          ListTile(
+            title: const Text('Internationalization Example'),
+            subtitle: const Text(
+              'Show validation messages in built-in languages',
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap:
+                () =>
+                    Navigator.of(context).pushNamed(L18nMessagesExample.route),
+          ),
+          const Divider(),
+          ListTile(
+            title: const Text('Custom Internationalization Example'),
+            subtitle: const Text(
+              'Show custom translations for validation messages',
+            ),
+            trailing: const Icon(Icons.chevron_right),
+            onTap:
+                () => Navigator.of(
+                  context,
+                ).pushNamed(L18nCustomBundlesExample.route),
           ),
           const Divider(),
           // Here will come more examples.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -78,7 +78,7 @@ packages:
     source: hosted
     version: "5.0.0"
   flutter_localizations:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -30,6 +30,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/example/test/main_test.dart
+++ b/example/test/main_test.dart
@@ -7,6 +7,8 @@ void main() {
   ) async {
     await tester.pumpWidget(const MyApp());
 
+    await tester.pumpAndSettle();
+
     // Home visible
     expect(find.text('DJSF Examples'), findsOneWidget);
     expect(find.text('Very simple form'), findsOneWidget);
@@ -17,6 +19,87 @@ void main() {
 
     // Llegamos a la pantalla del ejemplo
     expect(find.text('DJSF Very Simple Example'), findsOneWidget);
+
+    // Volver atrás
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    // De nuevo en Home
+    expect(find.text('DJSF Examples'), findsOneWidget);
+  });
+
+  testWidgets('Home shows list and navigates to ValidationMessagesExample', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MyApp());
+
+    await tester.pumpAndSettle();
+
+    // Home visible
+    expect(find.text('DJSF Examples'), findsOneWidget);
+    expect(find.text('Validation messages'), findsOneWidget);
+
+    // Tap en el item
+    await tester.tap(find.text('Validation messages'));
+    await tester.pumpAndSettle();
+
+    // Llegamos a la pantalla del ejemplo
+    expect(find.text('DJSF Validation messages'), findsOneWidget);
+
+    // Volver atrás
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    // De nuevo en Home
+    expect(find.text('DJSF Examples'), findsOneWidget);
+  });
+
+  testWidgets('Home shows list and navigates to L18nMessagesExample', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MyApp());
+
+    await tester.pumpAndSettle();
+
+    // Home visible
+    expect(find.text('DJSF Examples'), findsOneWidget);
+    expect(find.text('Internationalization Example'), findsOneWidget);
+
+    // Tap en el item
+    await tester.tap(find.text('Internationalization Example'));
+    await tester.pumpAndSettle();
+
+    // Llegamos a la pantalla del ejemplo
+    expect(find.text('DJSF Internationalization Example'), findsOneWidget);
+
+    // Volver atrás
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    // De nuevo en Home
+    expect(find.text('DJSF Examples'), findsOneWidget);
+  });
+
+  testWidgets('Home shows list and navigates to L18nCustomBundlesExample', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MyApp());
+
+    await tester.pumpAndSettle();
+
+    // Home visible
+    expect(find.text('DJSF Examples'), findsOneWidget);
+    expect(find.text('Custom Internationalization Example'), findsOneWidget);
+
+    // Tap en el item
+    await tester.tap(find.text('Custom Internationalization Example'));
+    await tester.pumpAndSettle();
+
+    // Llegamos a la pantalla del ejemplo
+    expect(
+      find.text('DJSF Custom Internationalization Example'),
+      findsOneWidget,
+    );
 
     // Volver atrás
     await tester.pageBack();

--- a/example/test/test/i18n_custom_bundle_example_test.dart
+++ b/example/test/test/i18n_custom_bundle_example_test.dart
@@ -1,0 +1,44 @@
+import 'package:example/examples/l18n_custom_bundle_example.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('L18nMessagesExample', () {
+    testWidgets(
+      'renders and switches required message between EN and ES shows custom message',
+      (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: L18nCustomBundlesExample()),
+        );
+
+        await tester.pumpAndSettle();
+
+        // App bar
+        expect(
+          find.text('DJSF Custom Internationalization Example'),
+          findsOneWidget,
+        );
+
+        // Language buttons exist
+        for (final code in languages) {
+          expect(find.text(code.toUpperCase()), findsWidgets);
+        }
+
+        // Start in English (default 'en')
+        // Submit empty form → should show English required message
+        await tester.tap(find.text('Submit'));
+        await tester.pumpAndSettle();
+        expect(find.text('My custom required message'), findsOneWidget);
+
+        // Switch to ES
+        await tester.tap(find.text('ES'));
+        await tester.pumpAndSettle();
+
+        // Submit again → should show Spanish required message
+        await tester.tap(find.text('Submit'));
+        await tester.pumpAndSettle();
+        expect(find.text('My custom required message'), findsOneWidget);
+      },
+    );
+  });
+}

--- a/example/test/test/i18n_messages_example_test.dart
+++ b/example/test/test/i18n_messages_example_test.dart
@@ -1,0 +1,53 @@
+import 'package:example/examples/l18n_messages_example.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('L18nMessagesExample', () {
+    testWidgets('renders and switches required message between EN and ES', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const MaterialApp(home: L18nMessagesExample()));
+
+      await tester.pumpAndSettle();
+
+      // App bar
+      expect(find.text('DJSF Internationalization Example'), findsOneWidget);
+
+      // Language buttons exist
+      for (final code in languages) {
+        expect(find.text(code.toUpperCase()), findsWidgets);
+      }
+
+      // Start in English (default 'en')
+      // Submit empty form → should show English required message
+      await tester.tap(find.text('Submit'));
+      await tester.pumpAndSettle();
+      expect(find.text('This field is required'), findsOneWidget);
+
+      // Switch to ES
+      await tester.tap(find.text('ES'));
+      await tester.pumpAndSettle();
+
+      // Submit again → should show Spanish required message
+      await tester.tap(find.text('Submit'));
+      await tester.pumpAndSettle();
+      expect(find.text('Este campo es obligatorio'), findsOneWidget);
+    });
+
+    testWidgets('switches to DE and shows the German required message', (
+      tester,
+    ) async {
+      await tester.pumpWidget(const MaterialApp(home: L18nMessagesExample()));
+
+      // Switch to DE
+      await tester.tap(find.text('DE'));
+      await tester.pumpAndSettle();
+
+      // Submit empty form → should show German required message
+      await tester.tap(find.text('Submit'));
+      await tester.pumpAndSettle();
+      expect(find.text('Dieses Feld ist erforderlich'), findsOneWidget);
+    });
+  });
+}

--- a/example/test/test/validation_messages_example_test.dart
+++ b/example/test/test/validation_messages_example_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:example/examples/validation_messages_example.dart';
+
+void main() {
+  group('ValidationMessagesExample', () {
+    testWidgets(
+      'renders and shows default + custom messages via transformErrors',
+      (tester) async {
+        await tester.pumpWidget(
+          const MaterialApp(home: ValidationMessagesExample()),
+        );
+
+        await tester.pumpAndSettle();
+
+        // App bar
+        expect(find.text('DJSF Validation messages'), findsOneWidget);
+
+        // Field labels
+        expect(find.text('Full Name'), findsOneWidget);
+        expect(find.text('Email'), findsOneWidget);
+        expect(find.text('Age'), findsOneWidget);
+
+        // 1) Submit empty → required for email (default message)
+        await tester.tap(find.text('Submit'));
+        await tester.pumpAndSettle();
+        expect(find.text('This field is required'), findsOneWidget);
+
+        // 2) Full Name too short (minLength: 5) → default minLength message
+        // TextField order (by creation): 0 Full Name, 1 Email, 2 Age
+        await tester.enterText(find.byType(TextField).at(0), 'Ana'); // length 3
+        await tester.tap(find.text('Submit'));
+        await tester.pumpAndSettle();
+        expect(find.text('Must be at least 5 characters'), findsOneWidget);
+
+        // 3) Email wrong pattern → custom transformErrors message
+        await tester.enterText(find.byType(TextField).at(1), 'nope');
+        await tester.tap(find.text('Submit'));
+        await tester.pumpAndSettle();
+        expect(
+          find.text('Custom message: Please enter a valid email address'),
+          findsOneWidget,
+        );
+
+        // 4) Age below minimum (min: 18) → custom transformErrors message
+        await tester.enterText(find.byType(TextField).at(2), '16');
+        await tester.tap(find.text('Submit'));
+        await tester.pumpAndSettle();
+        expect(
+          find.text('Custom message: Must be at least 18 years old'),
+          findsOneWidget,
+        );
+
+        // (Optional) Fix values → errors disappear
+        await tester.enterText(
+          find.byType(TextField).at(0),
+          'Alice Doe',
+        ); // >= 5
+        await tester.enterText(
+          find.byType(TextField).at(1),
+          'user@example.com',
+        );
+        await tester.enterText(find.byType(TextField).at(2), '21');
+        await tester.tap(find.text('Submit'));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Must be at least 5 characters'), findsNothing);
+        expect(
+          find.text('Custom message: Please enter a valid email address'),
+          findsNothing,
+        );
+        expect(
+          find.text('Custom message: Must be at least 18 years old'),
+          findsNothing,
+        );
+      },
+    );
+  });
+}

--- a/example/test/test/very_simple_form_example_test.dart
+++ b/example/test/test/very_simple_form_example_test.dart
@@ -9,6 +9,8 @@ void main() {
     (tester) async {
       await tester.pumpWidget(const MaterialApp(home: VerySimpleFormExample()));
 
+      await tester.pumpAndSettle();
+
       // App bar title
       expect(find.text('DJSF Very Simple Example'), findsOneWidget);
 

--- a/lib/dart_json_schema_form.dart
+++ b/lib/dart_json_schema_form.dart
@@ -1,1 +1,2 @@
 export 'src/djsf_form.dart';
+export 'src/types/types.dart';

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1,0 +1,15 @@
+{
+  "@@locale": "de",
+  "required": "Dieses Feld ist erforderlich",
+  "minLength": "Muss mindestens {limit} Zeichen haben",
+  "@minLength": {"placeholders": {"limit": {}}},
+  "maxLength": "Darf höchstens {limit} Zeichen haben",
+  "@maxLength": {"placeholders": {"limit": {}}},
+  "pattern": "Ungültiges Format",
+  "min": "Muss ≥ {limit} sein",
+  "@min": {"placeholders": {"limit": {}}},
+  "max": "Muss ≤ {limit} sein",
+  "@max": {"placeholders": {"limit": {}}},
+  "equals": "Muss {allowed} entsprechen",
+  "@equals": {"placeholders": {"allowed": {}}}
+}

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,0 +1,15 @@
+{
+  "@@locale": "en",
+  "required": "This field is required",
+  "minLength": "Must be at least {limit} characters",
+  "@minLength": {"placeholders": {"limit": {}}},
+  "maxLength": "Must be at most {limit} characters",
+  "@maxLength": {"placeholders": {"limit": {}}},
+  "pattern": "Invalid format",
+  "min": "Must be ≥ {limit}",
+  "@min": {"placeholders": {"limit": {}}},
+  "max": "Must be ≤ {limit}",
+  "@max": {"placeholders": {"limit": {}}},
+  "equals": "Must equal {allowed}",
+  "@equals": {"placeholders": {"allowed": {}}}
+}

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -1,0 +1,15 @@
+{
+  "@@locale": "es",
+  "required": "Este campo es obligatorio",
+  "minLength": "Debe tener al menos {limit} caracteres",
+  "@minLength": {"placeholders": {"limit": {}}},
+  "maxLength": "Debe tener como máximo {limit} caracteres",
+  "@maxLength": {"placeholders": {"limit": {}}},
+  "pattern": "Formato inválido",
+  "min": "Debe ser ≥ {limit}",
+  "@min": {"placeholders": {"limit": {}}},
+  "max": "Debe ser ≤ {limit}",
+  "@max": {"placeholders": {"limit": {}}},
+  "equals": "Debe ser igual a {allowed}",
+  "@equals": {"placeholders": {"allowed": {}}}
+}

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1,0 +1,15 @@
+{
+  "@@locale": "fr",
+  "required": "Ce champ est obligatoire",
+  "minLength": "Doit contenir au moins {limit} caractères",
+  "@minLength": {"placeholders": {"limit": {}}},
+  "maxLength": "Doit contenir au maximum {limit} caractères",
+  "@maxLength": {"placeholders": {"limit": {}}},
+  "pattern": "Format invalide",
+  "min": "Doit être ≥ {limit}",
+  "@min": {"placeholders": {"limit": {}}},
+  "max": "Doit être ≤ {limit}",
+  "@max": {"placeholders": {"limit": {}}},
+  "equals": "Doit être égal à {allowed}",
+  "@equals": {"placeholders": {"allowed": {}}}
+}

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -1,0 +1,15 @@
+{
+  "@@locale": "it",
+  "required": "Questo campo è obbligatorio",
+  "minLength": "Deve contenere almeno {limit} caratteri",
+  "@minLength": {"placeholders": {"limit": {}}},
+  "maxLength": "Deve contenere al massimo {limit} caratteri",
+  "@maxLength": {"placeholders": {"limit": {}}},
+  "pattern": "Formato non valido",
+  "min": "Deve essere ≥ {limit}",
+  "@min": {"placeholders": {"limit": {}}},
+  "max": "Deve essere ≤ {limit}",
+  "@max": {"placeholders": {"limit": {}}},
+  "equals": "Deve essere uguale a {allowed}",
+  "@equals": {"placeholders": {"allowed": {}}}
+}

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -1,0 +1,15 @@
+{
+  "@@locale": "ja",
+  "required": "この項目は必須です",
+  "minLength": "{limit}文字以上で入力してください",
+  "@minLength": {"placeholders": {"limit": {}}},
+  "maxLength": "{limit}文字以下で入力してください",
+  "@maxLength": {"placeholders": {"limit": {}}},
+  "pattern": "形式が正しくありません",
+  "min": "{limit}以上である必要があります",
+  "@min": {"placeholders": {"limit": {}}},
+  "max": "{limit}以下である必要があります",
+  "@max": {"placeholders": {"limit": {}}},
+  "equals": "{allowed}と等しくなければなりません",
+  "@equals": {"placeholders": {"allowed": {}}}
+}

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -1,0 +1,15 @@
+{
+  "@@locale": "nl",
+  "required": "Dit veld is verplicht",
+  "minLength": "Moet minstens {limit} tekens bevatten",
+  "@minLength": {"placeholders": {"limit": {}}},
+  "maxLength": "Mag maximaal {limit} tekens bevatten",
+  "@maxLength": {"placeholders": {"limit": {}}},
+  "pattern": "Ongeldig formaat",
+  "min": "Moet ≥ {limit} zijn",
+  "@min": {"placeholders": {"limit": {}}},
+  "max": "Moet ≤ {limit} zijn",
+  "@max": {"placeholders": {"limit": {}}},
+  "equals": "Moet gelijk zijn aan {allowed}",
+  "@equals": {"placeholders": {"allowed": {}}}
+}

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -1,0 +1,15 @@
+{
+  "@@locale": "pl",
+  "required": "To pole jest wymagane",
+  "minLength": "Musi mieć co najmniej {limit} znaków",
+  "@minLength": {"placeholders": {"limit": {}}},
+  "maxLength": "Może mieć co najwyżej {limit} znaków",
+  "@maxLength": {"placeholders": {"limit": {}}},
+  "pattern": "Nieprawidłowy format",
+  "min": "Musi być ≥ {limit}",
+  "@min": {"placeholders": {"limit": {}}},
+  "max": "Musi być ≤ {limit}",
+  "@max": {"placeholders": {"limit": {}}},
+  "equals": "Musi być równe {allowed}",
+  "@equals": {"placeholders": {"allowed": {}}}
+}

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -1,0 +1,15 @@
+{
+  "@@locale": "pt",
+  "required": "Este campo é obrigatório",
+  "minLength": "Deve ter pelo menos {limit} caracteres",
+  "@minLength": {"placeholders": {"limit": {}}},
+  "maxLength": "Deve ter no máximo {limit} caracteres",
+  "@maxLength": {"placeholders": {"limit": {}}},
+  "pattern": "Formato inválido",
+  "min": "Deve ser ≥ {limit}",
+  "@min": {"placeholders": {"limit": {}}},
+  "max": "Deve ser ≤ {limit}",
+  "@max": {"placeholders": {"limit": {}}},
+  "equals": "Deve ser igual a {allowed}",
+  "@equals": {"placeholders": {"allowed": {}}}
+}

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -1,0 +1,15 @@
+{
+  "@@locale": "ru",
+  "required": "Это поле обязательно для заполнения",
+  "minLength": "Длина должна быть не менее {limit} символов",
+  "@minLength": {"placeholders": {"limit": {}}},
+  "maxLength": "Длина должна быть не более {limit} символов",
+  "@maxLength": {"placeholders": {"limit": {}}},
+  "pattern": "Недопустимый формат",
+  "min": "Значение должно быть ≥ {limit}",
+  "@min": {"placeholders": {"limit": {}}},
+  "max": "Значение должно быть ≤ {limit}",
+  "@max": {"placeholders": {"limit": {}}},
+  "equals": "Значение должно быть равно {allowed}",
+  "@equals": {"placeholders": {"allowed": {}}}
+}

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -1,0 +1,15 @@
+{
+  "@@locale": "zh",
+  "required": "此字段为必填项",
+  "minLength": "至少需要 {limit} 个字符",
+  "@minLength": {"placeholders": {"limit": {}}},
+  "maxLength": "最多 {limit} 个字符",
+  "@maxLength": {"placeholders": {"limit": {}}},
+  "pattern": "格式不正确",
+  "min": "必须 ≥ {limit}",
+  "@min": {"placeholders": {"limit": {}}},
+  "max": "必须 ≤ {limit}",
+  "@max": {"placeholders": {"limit": {}}},
+  "equals": "必须等于 {allowed}",
+  "@equals": {"placeholders": {"allowed": {}}}
+}

--- a/lib/src/djsf_form.dart
+++ b/lib/src/djsf_form.dart
@@ -1,5 +1,6 @@
 import 'package:dart_json_schema_form/src/parsers/schema_parser.dart';
 import 'package:dart_json_schema_form/src/renderers/form_renderer.dart';
+import 'package:dart_json_schema_form/src/types/i18n.dart';
 import 'package:flutter/material.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 import 'types/types.dart';
@@ -9,13 +10,40 @@ import 'types/types.dart';
 /// Input: `schema` (RJSF-compatible) and `uiSchema`.
 /// Currently only returns an empty placeholder widget.
 class DjsfForm extends StatelessWidget {
+  /// Creates a DJSF form from a JSON Schema and (optionally) uiSchema.
+  ///
+  /// Localization:
+  /// - You can pass [locale] (e.g., `'es'`, `'de'`) to select one of the built‑in
+  ///   message bundles without depending on `intl`.
+  /// - Or you can pass a custom [messagesBundle] (for example an Intl‑backed
+  ///   implementation) to fully control validation messages.
+  ///
+  /// Precedence:
+  /// - If both [messagesBundle] and [locale] are provided, **[messagesBundle]
+  ///   takes precedence**.
+  ///
+  /// Example:
+  /// ```dart
+  /// /// Using a built-in bundle (no intl required):
+  /// DjsfForm(schema: schema, locale: 'es');
+  ///
+  /// /// Using a custom (intl) bundle:
+  /// DjsfForm(schema: schema, messagesBundle: IntlBundle());
+  ///
+  /// /// Global default for entire app (optional):
+  /// DjsfConfig.init(locale: 'de'); /// or DjsfConfig.init(bundle: IntlBundle());
+  /// ```
   const DjsfForm({
     super.key,
     required this.schema,
     this.uiSchema,
     this.formData,
     this.onChanged,
-    this.transformErrors, // RJSF-style hook
+    this.locale,
+    this.messagesBundle,
+    this.transformErrors,
+
+    /// RJSF-style hook
   });
 
   final JsonMap schema;
@@ -23,48 +51,123 @@ class DjsfForm extends StatelessWidget {
   final JsonMap? formData;
   final ValueChanged<JsonMap>? onChanged;
 
-  /// RJSF-style transformErrors hook
+  /// RJSF-style hook to transform validation errors programmatically.
+  /// Receives a list of errors and should return a (possibly modified) list.
   final TransformErrors? transformErrors;
+
+  /// Optional locale code (e.g., `'en'`, `'es'`, `'de'`, `'it'`, `'pt'`, `'fr'`,
+  /// `'nl'`, `'ja'`, `'zh'`, `'ru'`, `'pl'`).
+  ///
+  /// When provided, DJSF uses the corresponding **built‑in** message bundle
+  /// (no `intl` dependency required). This is a simple way to localize default
+  /// validation messages.
+  ///
+  /// If [messagesBundle] is also provided, that custom bundle **overrides** this
+  /// locale setting.
+  final String? locale;
+
+  /// Optional custom message bundle to produce validation messages for the
+  /// supported validation error.
+  ///
+  /// **note:** If added custom validation rules are not supported by the built-in
+  /// you should use [transformErrors] instead.
+  ///
+  /// Any custom bundle must implement the [DjsfMessageBundle] interface.
+  /// Example:
+  ///
+  /// ```dart
+  /// class MyCustomBundle extends DjsfMessageBundle {
+  ///   @override
+  ///   String equals(allowed) {
+  ///     return "My custom equals message $allowed";
+  ///   }
+  ///
+  ///   @override
+  ///   String max(num limit) {
+  ///     return "My custom max message $limit";
+  ///   }
+  ///
+  ///   @override
+  ///   String maxLength(int limit) {
+  ///     return "My custom maxLength message $limit";
+  ///   }
+  ///
+  ///   @override
+  ///   String min(num limit) {
+  ///     return "My custom min message $limit";
+  ///   }
+  ///
+  ///   @override
+  ///   String minLength(int limit) {
+  ///     return "My custom minLength message $limit";
+  ///   }
+  ///
+  ///   @override
+  ///   String pattern() {
+  ///     return "My custom pattern message";
+  ///   }
+  ///
+  ///   @override
+  ///   String required() {
+  ///     return "My custom required message";
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// **Precedence:** when set, this bundle **takes priority** over [locale]
+  /// and over any global default configured with `DjsfConfig.init(...)`.
+  final DjsfMessageBundle? messagesBundle;
 
   @override
   Widget build(BuildContext context) {
     final String title = schema['title'] ?? 'DJSF Form Placeholder';
     final String? description = schema['description'];
 
-    return ReactiveFormBuilder(
-      form: () => SchemaParser.buildFormGroup(schema, formData: formData),
-      builder: (context, form, child) {
-        return SingleChildScrollView(
-          padding: const EdgeInsets.all(8),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(title,
-                  style: const TextStyle(
-                      fontWeight: FontWeight.bold, fontSize: 18)),
-              const Divider(),
-              if (description != null) Text(description),
-              const SizedBox(height: 16),
-              FormRenderer(
-                form: form,
-                schema: schema,
-                transformErrors: transformErrors, // pass through
-              ),
-              const SizedBox(height: 24),
-              ElevatedButton(
-                onPressed: () {
-                  if (form.valid) {
-                    debugPrint('Form value: ${form.value}');
-                  } else {
-                    form.markAllAsTouched();
-                  }
-                },
-                child: const Text('Submit'),
-              ),
-            ],
-          ),
-        );
-      },
-    );
+    return FutureBuilder<DjsfMessageBundle>(
+        future: DjsfConfig.resolve(locale: locale, bundle: messagesBundle),
+        builder: (context, snap) {
+          if (!snap.hasData) {
+            return SizedBox.shrink();
+          }
+
+          assert(!snap.hasError, 'Error loading message bundle: ${snap.error}');
+
+          return ReactiveFormBuilder(
+            form: () => SchemaParser.buildFormGroup(schema, formData: formData),
+            builder: (context, form, child) {
+              return SingleChildScrollView(
+                padding: const EdgeInsets.all(8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(title,
+                        style: const TextStyle(
+                            fontWeight: FontWeight.bold, fontSize: 18)),
+                    const Divider(),
+                    if (description != null) Text(description),
+                    const SizedBox(height: 16),
+                    FormRenderer(
+                      form: form,
+                      schema: schema,
+                      transformErrors: transformErrors, // pass through
+                      messages: snap.data!,
+                    ),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: () {
+                        if (form.valid) {
+                          debugPrint('Form value: ${form.value}');
+                        } else {
+                          form.markAllAsTouched();
+                        }
+                      },
+                      child: const Text('Submit'),
+                    ),
+                  ],
+                ),
+              );
+            },
+          );
+        });
   }
 }

--- a/lib/src/djsf_form.dart
+++ b/lib/src/djsf_form.dart
@@ -2,7 +2,6 @@ import 'package:dart_json_schema_form/src/parsers/schema_parser.dart';
 import 'package:dart_json_schema_form/src/renderers/form_renderer.dart';
 import 'package:flutter/material.dart';
 import 'package:reactive_forms/reactive_forms.dart';
-
 import 'types/types.dart';
 
 /// DJSF (Dart JSON Schema Form)
@@ -16,12 +15,16 @@ class DjsfForm extends StatelessWidget {
     this.uiSchema,
     this.formData,
     this.onChanged,
+    this.transformErrors, // RJSF-style hook
   });
 
   final JsonMap schema;
   final JsonMap? uiSchema;
   final JsonMap? formData;
   final ValueChanged<JsonMap>? onChanged;
+
+  /// RJSF-style transformErrors hook
+  final TransformErrors? transformErrors;
 
   @override
   Widget build(BuildContext context) {
@@ -32,19 +35,21 @@ class DjsfForm extends StatelessWidget {
       form: () => SchemaParser.buildFormGroup(schema, formData: formData),
       builder: (context, form, child) {
         return SingleChildScrollView(
-          padding: const EdgeInsets.all(8.0),
+          padding: const EdgeInsets.all(8),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                title,
-                style:
-                    const TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
-              ),
+              Text(title,
+                  style: const TextStyle(
+                      fontWeight: FontWeight.bold, fontSize: 18)),
               const Divider(),
               if (description != null) Text(description),
               const SizedBox(height: 16),
-              FormRenderer(form: form, schema: schema),
+              FormRenderer(
+                form: form,
+                schema: schema,
+                transformErrors: transformErrors, // pass through
+              ),
               const SizedBox(height: 24),
               ElevatedButton(
                 onPressed: () {

--- a/lib/src/i18n/bundles.dart
+++ b/lib/src/i18n/bundles.dart
@@ -1,0 +1,29 @@
+import '../../generated/l10n.dart';
+import '../types/types.dart';
+
+/// Intl-based implementation of DjsfMessageBundle.
+/// Requires that you generated localization code from .arb files.
+class IntlBundle implements DjsfMessageBundle {
+  const IntlBundle();
+
+  @override
+  String required() => S.current.required;
+
+  @override
+  String minLength(int limit) => S.current.minLength(limit);
+
+  @override
+  String maxLength(int limit) => S.current.maxLength(limit);
+
+  @override
+  String pattern() => S.current.pattern;
+
+  @override
+  String min(num limit) => S.current.min(limit);
+
+  @override
+  String max(num limit) => S.current.max(limit);
+
+  @override
+  String equals(dynamic allowed) => S.current.equals(allowed);
+}

--- a/lib/src/parsers/schema_parser.dart
+++ b/lib/src/parsers/schema_parser.dart
@@ -4,9 +4,13 @@ import '../types/types.dart';
 /// Utility class that converts JSON Schema into a Reactive Forms FormGroup.
 class SchemaParser {
   /// Builds a FormGroup from the given JSON Schema.
-  /// - Each property in the schema becomes a typed FormControl based on `type`.
-  /// - Initial value is `null` for now.
-  static FormGroup buildFormGroup(JsonMap schema, {JsonMap? formData}) {
+  /// - Each property becomes a typed FormControl.
+  /// - Initial value comes from `formData` > schema `default` > null.
+  /// - Validators supported: `required`, `minLength`, `maxLength` (string fields).
+  static FormGroup buildFormGroup(
+    JsonMap schema, {
+    JsonMap? formData,
+  }) {
     final rawProps = schema['properties'];
 
     // Ensure properties exist and are valid
@@ -15,25 +19,33 @@ class SchemaParser {
     }
 
     final properties = Map<String, dynamic>.from(rawProps);
+
+    // Collect required fields from root-level "required": [...]
+    final requiredList = (schema['required'] is List)
+        ? List<String>.from(schema['required'] as List)
+        : const <String>[];
+    final requiredSet = requiredList.toSet();
+
     final controls = <String, AbstractControl>{};
 
     for (final entry in properties.entries) {
       final name = entry.key;
       final propSchema = _asMap(entry.value);
 
-      final initialValue = _resolveInitialValue(
-        name,
+      final initialValue = _resolveInitialValue(name, propSchema, formData);
+
+      final validators = _buildValidators(
         propSchema,
-        formData,
+        isRequired: requiredSet.contains(name),
       );
 
-      controls[name] = _buildTypedControl(propSchema, initialValue);
+      controls[name] = _buildTypedControl(propSchema, initialValue, validators);
     }
 
     return FormGroup(controls);
   }
 
-  /// Picks value from formData > schema.default > null
+  /// Resolve initial value by priority: formData > schema.default > null.
   static dynamic _resolveInitialValue(
     String name,
     JsonMap propSchema,
@@ -48,32 +60,98 @@ class SchemaParser {
     return null;
   }
 
-  /// Create a typed FormControl based on the JSON Schema `type`.
-  static AbstractControl _buildTypedControl(JsonMap propSchema, dynamic value) {
+  /// Build validators for a property.
+  /// Currently supports:
+  /// - required (from root "required" array)
+  /// - minLength / maxLength for string fields (JSON Schema keywords)
+  static List<Validator<dynamic>> _buildValidators(
+    JsonMap propSchema, {
+    required bool isRequired,
+  }) {
+    final type = (propSchema['type'] as String?)?.toLowerCase();
+    final validators = <Validator<dynamic>>[];
+
+    if (isRequired) {
+      validators.add(Validators.required);
+    }
+
+    if (propSchema.containsKey('const')) {
+      validators.add(Validators.equals(propSchema['const']));
+    }
+
+    if (type == 'string') {
+      final minLength = propSchema['minLength'];
+      final maxLength = propSchema['maxLength'];
+      final pattern = propSchema['pattern'];
+
+      if (minLength is int) {
+        validators.add(Validators.minLength(minLength));
+      }
+      if (maxLength is int) {
+        validators.add(Validators.maxLength(maxLength));
+      }
+      if (pattern is String && pattern.isNotEmpty) {
+        validators.add(Validators.pattern(RegExp(pattern)));
+      }
+    }
+
+    if (['integer', 'number'].contains(type)) {
+      final min = num.tryParse(propSchema['minimum'].toString());
+      final max = num.tryParse(propSchema['maximum'].toString());
+
+      if (min != null) {
+        validators.add(Validators.min(min));
+      }
+      if (max != null) {
+        validators.add(Validators.max(max));
+      }
+    }
+
+    return validators;
+  }
+
+  /// Create a typed control and attach validators.
+  static AbstractControl _buildTypedControl(
+    JsonMap propSchema,
+    dynamic value,
+    List<Validator<dynamic>> validators,
+  ) {
     final type = (propSchema['type'] as String?)?.toLowerCase();
 
     switch (type) {
       case 'string':
-        return FormControl<String>(value: value as String?);
+        return FormControl<String>(
+          value: value as String?,
+          validators: validators,
+        );
       case 'integer':
-        return FormControl<int>(value: value is int ? value : null);
+        return FormControl<int>(
+          value: value is int ? value : null,
+          validators: validators,
+        );
       case 'number':
         return FormControl<double>(
-            value: value is num ? value.toDouble() : null);
+          value: value is num ? value.toDouble() : null,
+          validators: validators,
+        );
       case 'boolean':
-        return FormControl<bool>(value: value is bool ? value : null);
+        return FormControl<bool>(
+          value: value is bool ? value : null,
+          validators: validators,
+        );
       case 'object':
-        // Placeholder: nested objects will be another FormGroup (empty for now)
         return FormGroup({});
       case 'array':
-        // Placeholder: arrays will be FormArray (empty for now)
         return FormArray([]);
       default:
-        return FormControl<String>(value: value?.toString());
+        // Fallback to string
+        return FormControl<String>(
+          value: value?.toString(),
+          validators: validators,
+        );
     }
   }
 
-  /// Ensures value is always returned as a Map<String, dynamic>.
   static JsonMap _asMap(dynamic v) {
     if (v is Map) return Map<String, dynamic>.from(v);
     return <String, dynamic>{};

--- a/lib/src/renderers/form_renderer.dart
+++ b/lib/src/renderers/form_renderer.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:reactive_forms/reactive_forms.dart';
-
+import '../types/djsf_error.dart';
 import '../types/types.dart';
 
 /// FormRenderer renders a list of form fields based on the schema and FormGroup.
@@ -9,10 +9,12 @@ class FormRenderer extends StatelessWidget {
     super.key,
     required this.form,
     required this.schema,
+    this.transformErrors,
   });
 
   final FormGroup form;
   final JsonMap schema;
+  final TransformErrors? transformErrors;
 
   @override
   Widget build(BuildContext context) {
@@ -20,7 +22,7 @@ class FormRenderer extends StatelessWidget {
 
     // Ensure properties exist and are valid
     if (rawProps == null || rawProps is! Map || rawProps.isEmpty) {
-      return SizedBox.shrink();
+      return const SizedBox.shrink();
     }
 
     final properties = Map<String, dynamic>.from(rawProps);
@@ -28,37 +30,136 @@ class FormRenderer extends StatelessWidget {
     return Column(
       children: form.controls.entries.map((entry) {
         final name = entry.key;
-        final control = entry.value;
         final propSchema = properties[name] as JsonMap? ?? {};
-
-        return _buildField(name, control, propSchema);
+        return _buildField(name, propSchema);
       }).toList(),
     );
   }
 
-  Widget _buildField(String name, AbstractControl control, JsonMap propSchema) {
-    final type = propSchema['type'] as String? ?? 'string';
-    final title = propSchema['title'] as String? ?? name;
+  Widget _buildField(String name, JsonMap propSchema) {
+    final type = (propSchema['type'] as String?) ?? 'string';
+    final title = (propSchema['title'] as String?) ?? name;
 
     switch (type) {
       case 'integer':
         return Padding(
-          padding: const EdgeInsets.only(bottom: 12.0),
+          padding: const EdgeInsets.only(bottom: 12),
           child: ReactiveTextField<int>(
             formControlName: name,
             decoration: InputDecoration(labelText: title),
             keyboardType: TextInputType.number,
+            validationMessages: _messagesForField(name, propSchema),
           ),
         );
       case 'string':
       default:
         return Padding(
-          padding: const EdgeInsets.only(bottom: 12.0),
+          padding: const EdgeInsets.only(bottom: 12),
           child: ReactiveTextField<String>(
             formControlName: name,
             decoration: InputDecoration(labelText: title),
+            validationMessages: _messagesForField(name, propSchema),
           ),
         );
     }
+  }
+
+  /// Build messages for one field.
+  /// Returns a Map of validatorKey → ValidationMessageFunction
+  Map<String, ValidationMessageFunction> _messagesForField(
+      String fieldName, JsonMap propSchema) {
+    return {
+      ValidationMessage.required: (error) {
+        return _transformSingleError(
+          fieldName,
+          'required',
+          'This field is required',
+          propSchema,
+        );
+      },
+      ValidationMessage.minLength: (error) {
+        final limit = propSchema['minLength'];
+        return _transformSingleError(
+          fieldName,
+          'minLength',
+          'Must be at least $limit characters',
+          propSchema,
+          params: {'limit': limit},
+        );
+      },
+      ValidationMessage.maxLength: (error) {
+        final limit = propSchema['maxLength'];
+        return _transformSingleError(
+          fieldName,
+          'maxLength',
+          'Must be at most $limit characters',
+          propSchema,
+          params: {'limit': limit},
+        );
+      },
+      ValidationMessage.pattern: (error) {
+        return _transformSingleError(
+          fieldName,
+          'pattern',
+          'Invalid format',
+          propSchema,
+          params: {'pattern': propSchema['pattern']},
+        );
+      },
+      ValidationMessage.min: (error) {
+        final limit = propSchema['minimum'];
+        return _transformSingleError(
+          fieldName,
+          'min',
+          'Must be ≥ $limit',
+          propSchema,
+          params: {'limit': limit},
+        );
+      },
+      ValidationMessage.max: (error) {
+        final limit = propSchema['maximum'];
+        return _transformSingleError(
+          fieldName,
+          'max',
+          'Must be ≤ $limit',
+          propSchema,
+          params: {'limit': limit},
+        );
+      },
+      ValidationMessage.equals: (error) {
+        final allowed = propSchema['const'];
+        return _transformSingleError(
+          fieldName,
+          'equals',
+          'Must equal $allowed',
+          propSchema,
+          params: {'allowed': allowed},
+        );
+      },
+    };
+  }
+
+  /// Apply transformErrors if provided
+  String _transformSingleError(
+    String fieldName,
+    String name,
+    String defaultMessage,
+    JsonMap propSchema, {
+    Map<String, Object?>? params,
+  }) {
+    final error = DjsfError(
+      name: name,
+      property: '.$fieldName',
+      message: defaultMessage,
+      params: params,
+    );
+
+    if (transformErrors != null) {
+      final transformed = transformErrors!([error]);
+      if (transformed.isNotEmpty) {
+        return transformed.first.message;
+      }
+    }
+    return defaultMessage;
   }
 }

--- a/lib/src/renderers/form_renderer.dart
+++ b/lib/src/renderers/form_renderer.dart
@@ -1,5 +1,7 @@
+import 'package:dart_json_schema_form/src/i18n/bundles.dart';
 import 'package:flutter/material.dart';
 import 'package:reactive_forms/reactive_forms.dart';
+
 import '../types/djsf_error.dart';
 import '../types/types.dart';
 
@@ -10,11 +12,13 @@ class FormRenderer extends StatelessWidget {
     required this.form,
     required this.schema,
     this.transformErrors,
+    this.messages = const IntlBundle(),
   });
 
   final FormGroup form;
   final JsonMap schema;
   final TransformErrors? transformErrors;
+  final DjsfMessageBundle messages;
 
   @override
   Widget build(BuildContext context) {
@@ -73,26 +77,30 @@ class FormRenderer extends StatelessWidget {
         return _transformSingleError(
           fieldName,
           'required',
-          'This field is required',
+          messages.required(),
           propSchema,
         );
       },
       ValidationMessage.minLength: (error) {
-        final limit = propSchema['minLength'];
+        final limit = (propSchema['minLength'] is int)
+            ? propSchema['minLength'] as int
+            : 0;
         return _transformSingleError(
           fieldName,
           'minLength',
-          'Must be at least $limit characters',
+          messages.minLength(limit),
           propSchema,
           params: {'limit': limit},
         );
       },
       ValidationMessage.maxLength: (error) {
-        final limit = propSchema['maxLength'];
+        final limit = (propSchema['maxLength'] is int)
+            ? propSchema['maxLength'] as int
+            : 0;
         return _transformSingleError(
           fieldName,
           'maxLength',
-          'Must be at most $limit characters',
+          messages.maxLength(limit),
           propSchema,
           params: {'limit': limit},
         );
@@ -101,29 +109,31 @@ class FormRenderer extends StatelessWidget {
         return _transformSingleError(
           fieldName,
           'pattern',
-          'Invalid format',
+          messages.pattern(),
           propSchema,
           params: {'pattern': propSchema['pattern']},
         );
       },
       ValidationMessage.min: (error) {
         final limit = propSchema['minimum'];
+        final numLimit = (limit is num) ? limit : num.tryParse('$limit');
         return _transformSingleError(
           fieldName,
           'min',
-          'Must be ≥ $limit',
+          messages.min(numLimit ?? 0),
           propSchema,
-          params: {'limit': limit},
+          params: {'limit': numLimit},
         );
       },
       ValidationMessage.max: (error) {
         final limit = propSchema['maximum'];
+        final numLimit = (limit is num) ? limit : num.tryParse('$limit');
         return _transformSingleError(
           fieldName,
           'max',
-          'Must be ≤ $limit',
+          messages.max(numLimit ?? 0),
           propSchema,
-          params: {'limit': limit},
+          params: {'limit': numLimit},
         );
       },
       ValidationMessage.equals: (error) {
@@ -131,7 +141,7 @@ class FormRenderer extends StatelessWidget {
         return _transformSingleError(
           fieldName,
           'equals',
-          'Must equal $allowed',
+          messages.equals(allowed),
           propSchema,
           params: {'allowed': allowed},
         );

--- a/lib/src/types/djsf_error.dart
+++ b/lib/src/types/djsf_error.dart
@@ -1,0 +1,14 @@
+/// One error item (loosely mirrors RJSF’s error object)
+class DjsfError {
+  DjsfError({
+    required this.name, // e.g., 'required', 'minLength', 'pattern', 'min', 'max', 'equals'
+    required this.property, // path of the field, e.g., '.firstName'
+    required this.message, // user-facing message
+    this.params, // keyword-specific params (minLength, maxLength, minimum, maximum, pattern, const, etc.)
+  });
+
+  final String name;
+  final String property;
+  String message;
+  final Map<String, Object?>? params;
+}

--- a/lib/src/types/i18n.dart
+++ b/lib/src/types/i18n.dart
@@ -1,0 +1,40 @@
+import 'dart:ui';
+
+import 'package:dart_json_schema_form/src/types/types.dart';
+
+import '../../generated/l10n.dart';
+import '../i18n/bundles.dart';
+
+/// Global configuration with defaults and a registry of built-in bundles.
+class DjsfConfig {
+  static String _defaultLocale = 'en';
+  static DjsfMessageBundle? _defaultBundle;
+
+  /// Optional global init; call once in your app entrypoint if you want.
+  static Future<void> init({String? locale, DjsfMessageBundle? bundle}) {
+    if (locale != null) _defaultLocale = locale;
+    if (bundle != null) _defaultBundle = bundle;
+    return resolve(locale: _defaultLocale, bundle: _defaultBundle);
+  }
+
+  /// Resolve a bundle using priority:
+  /// 1) explicit bundle
+  /// 2) explicit locale
+  /// 3) global bundle set via init
+  /// 4) builtin by global/default locale
+  /// 5) builtin 'en'
+  static Future<DjsfMessageBundle> resolve(
+      {String? locale, DjsfMessageBundle? bundle}) async {
+    if (bundle != null) return bundle;
+
+    if (locale != null) {
+      await S.load(Locale(locale));
+      return IntlBundle();
+    }
+
+    if (_defaultBundle != null) return _defaultBundle!;
+
+    await S.load(Locale(_defaultLocale));
+    return IntlBundle();
+  }
+}

--- a/lib/src/types/types.dart
+++ b/lib/src/types/types.dart
@@ -3,3 +3,14 @@ import 'djsf_error.dart';
 typedef JsonMap = Map<String, dynamic>;
 
 typedef TransformErrors = List<DjsfError> Function(List<DjsfError> errors);
+
+/// Contract for a message bundle (could be backed by Intl or simple maps).
+abstract class DjsfMessageBundle {
+  String required();
+  String minLength(int limit);
+  String maxLength(int limit);
+  String pattern();
+  String min(num limit);
+  String max(num limit);
+  String equals(dynamic allowed);
+}

--- a/lib/src/types/types.dart
+++ b/lib/src/types/types.dart
@@ -1,1 +1,5 @@
+import 'djsf_error.dart';
+
 typedef JsonMap = Map<String, dynamic>;
+
+typedef TransformErrors = List<DjsfError> Function(List<DjsfError> errors);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_json_schema_form
 description: "A new Flutter project."
 version: 0.0.1
-homepage:
+homepage: ""
 
 environment:
   sdk: ^3.5.2
@@ -10,6 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+
+  intl: ^0.20.2
   reactive_forms: ^18.1.1
 
 dev_dependencies:
@@ -20,36 +24,5 @@ dev_dependencies:
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
-# The following section is specific to Flutter packages.
-flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/to/asset-from-package
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/to/resolution-aware-images
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/to/font-from-package
+flutter_intl:
+  enabled: true

--- a/test/djsf_form_test.dart
+++ b/test/djsf_form_test.dart
@@ -25,6 +25,8 @@ void main() {
         ),
       );
 
+      await tester.pumpAndSettle();
+
       // Assert
       expect(find.text("A registration form"), findsOneWidget);
     });
@@ -48,6 +50,8 @@ void main() {
         ),
       );
 
+      await tester.pumpAndSettle();
+
       // Assert
       expect(find.text("DJSF Form Placeholder"), findsOneWidget);
     });
@@ -65,6 +69,8 @@ void main() {
         ),
       );
 
+      await tester.pumpAndSettle();
+
       expect(find.text('Register users'), findsOneWidget);
     });
 
@@ -79,6 +85,8 @@ void main() {
           ),
         ),
       );
+
+      await tester.pumpAndSettle();
 
       expect(find.text('Register users'), findsNothing);
     });
@@ -97,6 +105,8 @@ void main() {
         MaterialApp(home: Scaffold(body: DjsfForm(schema: schema))),
       );
 
+      await tester.pumpAndSettle();
+
       expect(find.widgetWithText(ReactiveTextField<String>, "Username"),
           findsOneWidget);
     });
@@ -112,6 +122,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: DjsfForm(schema: schema))),
       );
+
+      await tester.pumpAndSettle();
 
       expect(
           find.widgetWithText(ReactiveTextField<int>, "Age"), findsOneWidget);
@@ -130,6 +142,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: DjsfForm(schema: schema))),
       );
+
+      await tester.pumpAndSettle();
 
       expect(find.widgetWithText(ReactiveTextField<String>, "First name"),
           findsOneWidget);
@@ -156,6 +170,8 @@ void main() {
         MaterialApp(home: Scaffold(body: DjsfForm(schema: schema))),
       );
 
+      await tester.pumpAndSettle();
+
       // The text "Chuck" should appear as the field's initial value
       expect(find.text('Chuck'), findsOneWidget);
     });
@@ -172,6 +188,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: DjsfForm(schema: schema))),
       );
+
+      await tester.pumpAndSettle();
 
       // Integer defaults are rendered as text in the input
       expect(find.text('42'), findsOneWidget);
@@ -200,6 +218,8 @@ void main() {
         ),
       );
 
+      await tester.pumpAndSettle();
+
       // Should show the override, not the default
       expect(find.text('Bruce'), findsOneWidget);
       expect(find.text('Chuck'), findsNothing);
@@ -217,6 +237,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(home: Scaffold(body: DjsfForm(schema: schema))),
       );
+
+      await tester.pumpAndSettle();
 
       // No default or formData → no prefilled text (label still exists, but no value)
       expect(find.text('Nickname'), findsOneWidget);

--- a/test/i18n/i18n_required_message_test.dart
+++ b/test/i18n/i18n_required_message_test.dart
@@ -1,0 +1,58 @@
+// example/test/i18n_required_message_test.dart
+import 'package:dart_json_schema_form/src/i18n/bundles.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/generated/l10n.dart' as djsf_l10n;
+
+Widget _app(Locale locale) {
+  final schema = {
+    "title": "Form",
+    "required": ["username"],
+    "properties": {
+      "username": {"type": "string", "title": "Username", "minLength": 5}
+    }
+  };
+
+  return MaterialApp(
+    locale: locale,
+    localizationsDelegates: const [
+      djsf_l10n.S.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+      GlobalCupertinoLocalizations.delegate,
+    ],
+    supportedLocales: djsf_l10n.S.delegate.supportedLocales,
+    home: Scaffold(
+      body: DjsfForm(
+        schema: schema,
+        messagesBundle: IntlBundle(),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('required message shows in English', (tester) async {
+    await tester.pumpWidget(_app(const Locale('en')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Submit'));
+    await tester.pumpAndSettle();
+
+    // From intl_en.arb
+    expect(find.text('This field is required'), findsOneWidget);
+  });
+
+  testWidgets('required message shows in Spanish', (tester) async {
+    await tester.pumpWidget(_app(const Locale('es')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Submit'));
+    await tester.pumpAndSettle();
+
+    // From intl_es.arb
+    expect(find.text('Este campo es obligatorio'), findsOneWidget);
+  });
+}

--- a/test/parsers/schema_parser_validators_test.dart
+++ b/test/parsers/schema_parser_validators_test.dart
@@ -1,0 +1,199 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+import 'package:dart_json_schema_form/src/parsers/schema_parser.dart';
+
+void main() {
+  group('SchemaParser validators', () {
+    test('required validator marks empty control as invalid', () {
+      final schema = {
+        "type": "object",
+        "required": ["firstName"],
+        "properties": {
+          "firstName": {"type": "string", "title": "First name"}
+        }
+      };
+
+      final form = SchemaParser.buildFormGroup(schema);
+
+      final control = form.control('firstName') as FormControl<String>;
+      expect(control.invalid, isTrue);
+      expect(control.hasError(ValidationMessage.required), isTrue);
+
+      control.value = 'Alice';
+      expect(control.valid, isTrue);
+    });
+
+    test('minLength validator for string', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "password": {"type": "string", "minLength": 3}
+        }
+      };
+
+      final form = SchemaParser.buildFormGroup(schema);
+      final control = form.control('password') as FormControl<String>;
+
+      control.value = 'ab'; // too short
+      expect(control.hasError(ValidationMessage.minLength), isTrue);
+
+      control.value = 'abc'; // exactly min length
+      expect(control.hasError(ValidationMessage.minLength), isFalse);
+      expect(control.valid, isTrue);
+    });
+
+    test('maxLength validator for string', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "code": {"type": "string", "maxLength": 5}
+        }
+      };
+
+      final form = SchemaParser.buildFormGroup(schema);
+      final control = form.control('code') as FormControl<String>;
+
+      control.value = 'abcdef'; // too long
+      expect(control.hasError(ValidationMessage.maxLength), isTrue);
+
+      control.value = 'abcde'; // exactly max length
+      expect(control.hasError(ValidationMessage.maxLength), isFalse);
+      expect(control.valid, isTrue);
+    });
+
+    test('combines required + minLength + maxLength', () {
+      final schema = {
+        "type": "object",
+        "required": ["username"],
+        "properties": {
+          "username": {
+            "type": "string",
+            "minLength": 3,
+            "maxLength": 8,
+          }
+        }
+      };
+
+      final form = SchemaParser.buildFormGroup(schema);
+      final c = form.control('username') as FormControl<String>;
+
+      // initially null → required error
+      expect(c.hasError(ValidationMessage.required), isTrue);
+
+      // too short
+      c.value = 'ab';
+      expect(c.hasError(ValidationMessage.minLength), isTrue);
+
+      // too long
+      c.value = 'abcdefghij';
+      expect(c.hasError(ValidationMessage.maxLength), isTrue);
+
+      // valid
+      c.value = 'charlie';
+      expect(c.valid, isTrue);
+    });
+    test('const validator: value must equal constant', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "code": {"type": "string", "const": "XYZ"}
+        }
+      };
+
+      final form = SchemaParser.buildFormGroup(schema);
+      final c = form.control('code') as FormControl<String>;
+
+      c.value = 'ABC';
+      expect(c.hasError(ValidationMessage.equals), isTrue);
+
+      c.value = 'XYZ';
+      expect(c.valid, isTrue);
+    });
+
+    test('pattern validator: must match regex', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "email": {"type": "string", "pattern": r"^[^\s@]+@[^\s@]+\.[^\s@]+$"}
+        }
+      };
+
+      final form = SchemaParser.buildFormGroup(schema);
+      final c = form.control('email') as FormControl<String>;
+
+      c.value = 'not-an-email';
+      expect(c.hasError(ValidationMessage.pattern), isTrue);
+
+      c.value = 'user@example.com';
+      expect(c.valid, isTrue);
+    });
+
+    test('minimum/maximum on integer', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "age": {"type": "integer", "minimum": 18, "maximum": 65}
+        }
+      };
+
+      final form = SchemaParser.buildFormGroup(schema);
+      final c = form.control('age') as FormControl<int>;
+
+      c.value = 16;
+      expect(c.hasError(ValidationMessage.min), isTrue);
+
+      c.value = 70;
+      expect(c.hasError(ValidationMessage.max), isTrue);
+
+      c.value = 35;
+      expect(c.valid, isTrue);
+    });
+
+    test('minimum/maximum on number (double)', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "rating": {"type": "number", "minimum": 1.5, "maximum": 4.5}
+        }
+      };
+
+      final form = SchemaParser.buildFormGroup(schema);
+      final c = form.control('rating') as FormControl<double>;
+
+      c.value = 1.0;
+      expect(c.hasError(ValidationMessage.min), isTrue);
+
+      c.value = 5.0;
+      expect(c.hasError(ValidationMessage.max), isTrue);
+
+      c.value = 3.3;
+      expect(c.valid, isTrue);
+    });
+
+    test('boolean required: present vs true (depends on chosen behavior)', () {
+      final schema = {
+        "type": "object",
+        "required": ["terms"],
+        "properties": {
+          "terms": {"type": "boolean"}
+        }
+      };
+
+      final form = SchemaParser.buildFormGroup(schema);
+      final c = form.control('terms') as FormControl<bool>;
+
+      // If using requiredTrue:
+      // initially null → requiredTrue error
+      // c.value = false; // still invalid
+      // expect(c.hasError(ValidationMessage.requiredTrue), isTrue);
+      // c.value = true;
+      // expect(c.valid, isTrue);
+
+      // If using required (present):
+      // initially null → required error
+      expect(c.hasError(ValidationMessage.required), isTrue);
+      c.value = false; // present but false
+      expect(c.hasError(ValidationMessage.required), isFalse);
+    });
+  });
+}

--- a/test/renderers/djsf_form_transform_errors_test.dart
+++ b/test/renderers/djsf_form_transform_errors_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+
+void main() {
+  testWidgets('transformErrors modifies messages like RJSF', (tester) async {
+    final schema = {
+      "title": "Form",
+      "required": ["email"],
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "pattern": r"^[^\s@]+@[^\s@]+\.[^\s@]+$"
+        }
+      }
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DjsfForm(
+            schema: schema,
+            transformErrors: (errors) {
+              return errors.map((e) {
+                if (e.name == 'required' && e.property == '.email') {
+                  e.message = 'Email is mandatory';
+                }
+                if (e.name == 'pattern' && e.property == '.email') {
+                  e.message = 'Email format is not valid';
+                }
+                return e;
+              }).toList();
+            },
+          ),
+        ),
+      ),
+    );
+
+    // trigger required
+    await tester.tap(find.text('Submit'));
+    await tester.pumpAndSettle();
+    expect(find.text('Email is mandatory'), findsOneWidget);
+
+    // trigger pattern
+    await tester.enterText(find.byType(TextField).first, 'nope');
+    await tester.tap(find.text('Submit'));
+    await tester.pumpAndSettle();
+    expect(find.text('Email format is not valid'), findsOneWidget);
+  });
+}

--- a/test/renderers/djsf_form_transform_errors_test.dart
+++ b/test/renderers/djsf_form_transform_errors_test.dart
@@ -37,6 +37,8 @@ void main() {
       ),
     );
 
+    await tester.pumpAndSettle();
+
     // trigger required
     await tester.tap(find.text('Submit'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
### Overview

This PR adds support for JSON Schema validation keywords in `dart_json_schema_form`. The parser now generates `FormControl` validators automatically based on schema definitions, and error messages are rendered with sensible defaults, with support for RJSF-style `transformErrors`.

### Changes

* **SchemaParser**

    * Added support for validation keywords:

        * `required` (via root `"required": [...]`)
        * `minLength` / `maxLength` for string fields
        * `pattern` (regex)
        * `minimum` / `maximum` for integer and number fields
        * `const` (via equals validator)
    * Default messages created for all validators.

* **FormRenderer / DjsfForm**

    * Connected validators to UI fields (`ReactiveTextField`).
    * Implemented error rendering with default messages.
    * Added RJSF-style `transformErrors` hook to allow per-field custom error messages.

* **Examples**

    * Added `ValidationMessagesExample` screen showcasing validators + `transformErrors`.
    * Added `L18nMessagesExample` demonstrating multi-language support with built-in bundles and locale switching.

* **Tests**

    * Unit tests for each validator type (`required`, `minLength`, `maxLength`, `pattern`, `min`, `max`, `equals`).
    * Widget tests for `DjsfForm` to assert validators attach correctly.
    * Example app tests validating both default and custom messages.