### PR TITLE
feat: uiSchema support and custom field registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,4 @@ jobs:
         run: flutter test --no-pub --coverage
 
       - name: Send codecov data
-        if: github.ref == 'refs/heads/master' # && github.event_name == 'push'
         run: bash <(curl -s https://codecov.io/bash) -t ${{ env.codecov_token }}

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -31,5 +31,5 @@ analyzer:
     invalid_annotation_target: ignore
   exclude:
     - lib/**/*.g.dart
-    - lib/generated/*
+    - lib/generated/**
     - test/**/*.mocks.dart

--- a/example/lib/examples/l18n_messages_example.dart
+++ b/example/lib/examples/l18n_messages_example.dart
@@ -6,6 +6,7 @@ final _schema = {
   "required": ["email"],
   "properties": {
     "firstName": {"type": "string", "title": "Full Name", "minLength": 5},
+    "lastName": {"type": "string", "title": "Last Name", "minLength": 5},
     "email": {
       "type": "string",
       "title": "Email",

--- a/example/lib/examples/ui_schema_simple_example.dart
+++ b/example/lib/examples/ui_schema_simple_example.dart
@@ -1,0 +1,85 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:flutter/material.dart';
+
+final _schema = {
+  "title": "A registration form",
+  "description": "A simple form example.",
+  "type": "object",
+  "required": ["firstName", "telephone"],
+  "properties": {
+    "firstName": {"type": "string", "title": "First name", "default": "Chuck"},
+    "lastName": {"type": "string", "title": "Last name"},
+    "age": {"type": "integer", "title": "Age", "minimum": 6},
+    "bio": {"type": "string", "title": "Bio"},
+    "password": {"type": "string", "title": "Password", "minLength": 3},
+    "telephone": {"type": "string", "title": "Telephone", "minLength": 10},
+  },
+};
+
+final _uiSchema = {
+  "firstName": {
+    "ui:autofocus": true,
+    "ui:emptyValue": "",
+    "ui:placeholder":
+        "ui:emptyValue causes this field to always be valid despite being required",
+    "ui:autocomplete": "family-name",
+  },
+  "lastName": {"ui:autocomplete": "given-name"},
+  "age": {"ui:title": "Age of person", "ui:description": "(earth year)"},
+  "bio": {"ui:widget": "textarea"},
+  "password": {"ui:widget": "password", "ui:help": "Hint: Make it strong!"},
+  "telephone": {
+    "ui:options": {"inputType": "tel"},
+  },
+};
+
+const languages = [
+  'en',
+  'es',
+  'de',
+  'it',
+  'pt',
+  'fr',
+  'nl',
+  'ja',
+  'zh',
+  'ru',
+  'pl',
+];
+
+class UiSchemaSimpleExample extends StatefulWidget {
+  static const route = '/simple-ui-example';
+
+  const UiSchemaSimpleExample({super.key});
+
+  @override
+  State<UiSchemaSimpleExample> createState() => _UiSchemaSimpleExampleState();
+}
+
+class _UiSchemaSimpleExampleState extends State<UiSchemaSimpleExample> {
+  String language = 'en';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('DJSF UI Schema Simple Example')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Flexible(
+                child: DjsfForm(
+                  schema: _schema,
+                  uiSchema: _uiSchema,
+                  locale: language,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/example/lib/examples/ui_schema_simple_example.dart
+++ b/example/lib/examples/ui_schema_simple_example.dart
@@ -19,12 +19,13 @@ final _schema = {
 final _uiSchema = {
   "firstName": {
     "ui:autofocus": true,
-    "ui:emptyValue": "",
-    "ui:placeholder":
-        "ui:emptyValue causes this field to always be valid despite being required",
+    "ui:emptyValue": " ",
     "ui:autocomplete": "family-name",
   },
-  "lastName": {"ui:autocomplete": "given-name"},
+  "lastName": {
+    "ui:autocomplete": "given-name",
+    "ui:placeholder": "Your lastname",
+  },
   "age": {"ui:title": "Age of person", "ui:description": "(earth year)"},
   "bio": {"ui:widget": "textarea"},
   "password": {"ui:widget": "password", "ui:help": "Hint: Make it strong!"},

--- a/example/lib/examples/ui_schema_simple_example.dart
+++ b/example/lib/examples/ui_schema_simple_example.dart
@@ -13,6 +13,7 @@ final _schema = {
     "bio": {"type": "string", "title": "Bio"},
     "password": {"type": "string", "title": "Password", "minLength": 3},
     "telephone": {"type": "string", "title": "Telephone", "minLength": 10},
+    "funds": {"type": "number", "title": "Funds", "minimum": 0.0},
   },
 };
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'examples/l18n_custom_bundle_example.dart';
 import 'examples/l18n_messages_example.dart';
+import 'examples/ui_schema_simple_example.dart';
 import 'examples/validation_messages_example.dart';
 import 'examples/very_simple_form_example.dart';
 
@@ -33,6 +34,7 @@ class MyApp extends StatelessWidget {
             (_) => const ValidationMessagesExample(),
         L18nMessagesExample.route: (_) => const L18nMessagesExample(),
         L18nCustomBundlesExample.route: (_) => const L18nCustomBundlesExample(),
+        UiSchemaSimpleExample.route: (_) => const UiSchemaSimpleExample(),
       },
     );
   }
@@ -91,6 +93,16 @@ class _HomePage extends StatelessWidget {
                 () => Navigator.of(
                   context,
                 ).pushNamed(L18nCustomBundlesExample.route),
+          ),
+          const Divider(),
+          ListTile(
+            title: const Text('UI Schema simple Example'),
+            subtitle: const Text('Simple example applying uiSchema'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap:
+                () => Navigator.of(
+                  context,
+                ).pushNamed(UiSchemaSimpleExample.route),
           ),
           const Divider(),
           // Here will come more examples.

--- a/lib/dart_json_schema_form.dart
+++ b/lib/dart_json_schema_form.dart
@@ -1,2 +1,3 @@
 export 'src/djsf_form.dart';
 export 'src/types/types.dart';
+export 'src/fields/fields.dart';

--- a/lib/src/djsf_form.dart
+++ b/lib/src/djsf_form.dart
@@ -153,6 +153,7 @@ class DjsfForm extends StatelessWidget {
                   FormRenderer(
                     form: form,
                     schema: schema,
+                    uiSchema: uiSchema,
                     transformErrors: transformErrors, // pass through
                     messages: snap.data!,
                   ),

--- a/lib/src/fields/context.dart
+++ b/lib/src/fields/context.dart
@@ -4,15 +4,17 @@ import 'package:dart_json_schema_form/src/types/types.dart';
 
 class DjsfFieldContext {
   DjsfFieldContext({
+    required this.type,
     required this.form,
     required this.schema,
-    required this.uiSchema,
     required this.path,
     required this.propSchema,
     required this.messages,
-    required this.transformErrors,
+    this.uiSchema,
+    this.transformErrors,
   });
 
+  final String type;
   final FormGroup form;
   final JsonMap schema;
   final JsonMap? uiSchema;

--- a/lib/src/fields/context.dart
+++ b/lib/src/fields/context.dart
@@ -1,0 +1,25 @@
+// lib/src/fields/context.dart
+import 'package:reactive_forms/reactive_forms.dart';
+import 'package:dart_json_schema_form/src/types/types.dart';
+
+class DjsfFieldContext {
+  DjsfFieldContext({
+    required this.form,
+    required this.schema,
+    required this.uiSchema,
+    required this.path,
+    required this.propSchema,
+    required this.messages,
+    required this.transformErrors,
+  });
+
+  final FormGroup form;
+  final JsonMap schema;
+  final JsonMap? uiSchema;
+  final String path;
+  final JsonMap propSchema;
+  final DjsfMessageBundle messages;
+  final TransformErrors? transformErrors;
+
+  AbstractControl get control => form.control(path);
+}

--- a/lib/src/fields/defaults.dart
+++ b/lib/src/fields/defaults.dart
@@ -2,7 +2,6 @@ import 'package:dart_json_schema_form/src/fields/defaults/number_field.dart';
 import 'package:dart_json_schema_form/src/fields/defaults/text_field.dart';
 import 'package:dart_json_schema_form/src/fields/defaults/textarea_field.dart';
 import 'package:dart_json_schema_form/src/fields/registry.dart';
-import 'package:flutter/material.dart';
 
 DjsfFieldRegistry defaultFieldRegistry() => DjsfFieldRegistry({
       'string': (ctx) => DjsfTextField<String>(
@@ -16,7 +15,6 @@ DjsfFieldRegistry defaultFieldRegistry() => DjsfFieldRegistry({
       'integer': (ctx) => DjsfNumberField<int>(
             formControlName: ctx.path,
             ctx: ctx,
-            keyboardType: TextInputType.number,
           ),
       'number': (ctx) => DjsfNumberField<num>(
             formControlName: ctx.path,

--- a/lib/src/fields/defaults.dart
+++ b/lib/src/fields/defaults.dart
@@ -1,0 +1,121 @@
+import 'package:dart_json_schema_form/src/fields/context.dart';
+import 'package:dart_json_schema_form/src/fields/defaults/number_field.dart';
+import 'package:dart_json_schema_form/src/fields/defaults/text_field.dart';
+import 'package:dart_json_schema_form/src/fields/defaults/textarea_field.dart';
+import 'package:dart_json_schema_form/src/fields/registry.dart';
+import 'package:dart_json_schema_form/src/utils/shared_messages.dart';
+import 'package:dart_json_schema_form/src/utils/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+DjsfFieldRegistry defaultFieldRegistry() => DjsfFieldRegistry({
+      'string': (ctx) => DjsfTextField<String>(
+            formControlName: ctx.path,
+            ctx: ctx,
+            keyboardType: TextInputType.text,
+          ),
+      'text': (ctx) => DjsfTextField<String>(
+            formControlName: ctx.path,
+            ctx: ctx,
+            keyboardType: TextInputType.text,
+          ),
+      'integer': (ctx) => DjsfNumberField<int>(
+            formControlName: ctx.path,
+            ctx: ctx,
+            keyboardType: TextInputType.text,
+          ),
+      'number': (ctx) => DjsfNumberField<num>(
+            formControlName: ctx.path,
+            ctx: ctx,
+            keyboardType: TextInputType.text,
+          ),
+      'password': (ctx) => DjsfTextField<String>(
+            formControlName: ctx.path,
+            ctx: ctx,
+            keyboardType: TextInputType.text,
+            obscureText: true,
+          ),
+      'textarea': (ctx) => DjsfTextAreaField(
+            formControlName: ctx.path,
+            ctx: ctx,
+            keyboardType: TextInputType.text,
+          ),
+      'tel': (ctx) => DjsfTextField<String>(
+            formControlName: ctx.path,
+            ctx: ctx,
+            keyboardType: TextInputType.phone,
+            obscureText: true,
+          ),
+      'email': (ctx) => DjsfTextField<String>(
+            formControlName: ctx.path,
+            ctx: ctx,
+            keyboardType: TextInputType.emailAddress,
+            obscureText: true,
+          ),
+    });
+
+ReactiveFormField _textField(
+  DjsfFieldContext ctx, {
+  bool obscureText = false,
+  TextInputType? keyboardType,
+}) {
+  final name = ctx.path;
+  final title = ctx.propSchema['title'] as String? ?? name;
+  final ui = readUiFor(ctx.uiSchema, name);
+  final decoration = inputDecorationFromUi(title, ui);
+  final messages = messagesForField(ctx, name, ctx.propSchema);
+
+  return ReactiveTextField<String>(
+    formControlName: name,
+    decoration: decoration,
+    obscureText: obscureText,
+    autofocus: ui.autofocus,
+    keyboardType: keyboardType ?? ui.keyboardTypeForString(),
+    autofillHints: ui.autocomplete != null ? [ui.autocomplete!] : null,
+    validationMessages: messages,
+    onChanged: (control) {
+      if ((control.value == null || control.value!.isEmpty) &&
+          ui.emptyValue != null) {
+        control.value = ui.emptyValue as String?;
+      }
+    },
+  );
+}
+
+ReactiveFormField _intField(DjsfFieldContext ctx) {
+  final name = ctx.path;
+  final title = ctx.propSchema['title'] as String? ?? name;
+  final ui = readUiFor(ctx.uiSchema, name);
+  final decoration = inputDecorationFromUi(title, ui);
+  final messages = messagesForField(ctx, name, ctx.propSchema);
+
+  return ReactiveTextField<int>(
+    formControlName: name,
+    decoration: decoration,
+    autofocus: ui.autofocus,
+    keyboardType: TextInputType.number,
+    validationMessages: messages,
+    onChanged: (control) {
+      if (control.value == null && ui.emptyValue != null) {
+        control.value = ui.emptyValue as int?;
+      }
+    },
+  );
+}
+
+ReactiveFormField _textArea(DjsfFieldContext ctx) {
+  final name = ctx.path;
+  final title = ctx.propSchema['title'] as String? ?? name;
+  final ui = readUiFor(ctx.uiSchema, name);
+  final decoration = inputDecorationFromUi(title, ui);
+  final messages = messagesForField(ctx, name, ctx.propSchema);
+
+  return ReactiveTextField<String>(
+    formControlName: name,
+    decoration: decoration,
+    autofocus: ui.autofocus,
+    minLines: 3,
+    maxLines: 6,
+    validationMessages: messages,
+  );
+}

--- a/lib/src/fields/defaults.dart
+++ b/lib/src/fields/defaults.dart
@@ -1,121 +1,42 @@
-import 'package:dart_json_schema_form/src/fields/context.dart';
 import 'package:dart_json_schema_form/src/fields/defaults/number_field.dart';
 import 'package:dart_json_schema_form/src/fields/defaults/text_field.dart';
 import 'package:dart_json_schema_form/src/fields/defaults/textarea_field.dart';
 import 'package:dart_json_schema_form/src/fields/registry.dart';
-import 'package:dart_json_schema_form/src/utils/shared_messages.dart';
-import 'package:dart_json_schema_form/src/utils/utils.dart';
 import 'package:flutter/material.dart';
-import 'package:reactive_forms/reactive_forms.dart';
 
 DjsfFieldRegistry defaultFieldRegistry() => DjsfFieldRegistry({
       'string': (ctx) => DjsfTextField<String>(
             formControlName: ctx.path,
             ctx: ctx,
-            keyboardType: TextInputType.text,
           ),
       'text': (ctx) => DjsfTextField<String>(
             formControlName: ctx.path,
             ctx: ctx,
-            keyboardType: TextInputType.text,
           ),
       'integer': (ctx) => DjsfNumberField<int>(
             formControlName: ctx.path,
             ctx: ctx,
-            keyboardType: TextInputType.text,
+            keyboardType: TextInputType.number,
           ),
       'number': (ctx) => DjsfNumberField<num>(
             formControlName: ctx.path,
             ctx: ctx,
-            keyboardType: TextInputType.text,
           ),
       'password': (ctx) => DjsfTextField<String>(
             formControlName: ctx.path,
             ctx: ctx,
-            keyboardType: TextInputType.text,
             obscureText: true,
           ),
       'textarea': (ctx) => DjsfTextAreaField(
             formControlName: ctx.path,
             ctx: ctx,
-            keyboardType: TextInputType.text,
           ),
       'tel': (ctx) => DjsfTextField<String>(
             formControlName: ctx.path,
             ctx: ctx,
-            keyboardType: TextInputType.phone,
-            obscureText: true,
           ),
       'email': (ctx) => DjsfTextField<String>(
             formControlName: ctx.path,
             ctx: ctx,
-            keyboardType: TextInputType.emailAddress,
-            obscureText: true,
           ),
     });
-
-ReactiveFormField _textField(
-  DjsfFieldContext ctx, {
-  bool obscureText = false,
-  TextInputType? keyboardType,
-}) {
-  final name = ctx.path;
-  final title = ctx.propSchema['title'] as String? ?? name;
-  final ui = readUiFor(ctx.uiSchema, name);
-  final decoration = inputDecorationFromUi(title, ui);
-  final messages = messagesForField(ctx, name, ctx.propSchema);
-
-  return ReactiveTextField<String>(
-    formControlName: name,
-    decoration: decoration,
-    obscureText: obscureText,
-    autofocus: ui.autofocus,
-    keyboardType: keyboardType ?? ui.keyboardTypeForString(),
-    autofillHints: ui.autocomplete != null ? [ui.autocomplete!] : null,
-    validationMessages: messages,
-    onChanged: (control) {
-      if ((control.value == null || control.value!.isEmpty) &&
-          ui.emptyValue != null) {
-        control.value = ui.emptyValue as String?;
-      }
-    },
-  );
-}
-
-ReactiveFormField _intField(DjsfFieldContext ctx) {
-  final name = ctx.path;
-  final title = ctx.propSchema['title'] as String? ?? name;
-  final ui = readUiFor(ctx.uiSchema, name);
-  final decoration = inputDecorationFromUi(title, ui);
-  final messages = messagesForField(ctx, name, ctx.propSchema);
-
-  return ReactiveTextField<int>(
-    formControlName: name,
-    decoration: decoration,
-    autofocus: ui.autofocus,
-    keyboardType: TextInputType.number,
-    validationMessages: messages,
-    onChanged: (control) {
-      if (control.value == null && ui.emptyValue != null) {
-        control.value = ui.emptyValue as int?;
-      }
-    },
-  );
-}
-
-ReactiveFormField _textArea(DjsfFieldContext ctx) {
-  final name = ctx.path;
-  final title = ctx.propSchema['title'] as String? ?? name;
-  final ui = readUiFor(ctx.uiSchema, name);
-  final decoration = inputDecorationFromUi(title, ui);
-  final messages = messagesForField(ctx, name, ctx.propSchema);
-
-  return ReactiveTextField<String>(
-    formControlName: name,
-    decoration: decoration,
-    autofocus: ui.autofocus,
-    minLines: 3,
-    maxLines: 6,
-    validationMessages: messages,
-  );
-}

--- a/lib/src/fields/defaults/number_field.dart
+++ b/lib/src/fields/defaults/number_field.dart
@@ -18,7 +18,7 @@ class DjsfNumberField<T extends num> extends ReactiveFormField<T, T> {
   }) : super(
           builder: (ReactiveFormFieldState<T, T> field) {
             final title = ctx.propSchema['title'] as String? ?? ctx.path;
-            final ui = readUiFor(ctx.uiSchema, ctx.path);
+            final ui = readUiFor(ctx);
             final decoration = inputDecorationFromUi(title, ui);
             final messages = messagesForField(ctx, ctx.path, ctx.propSchema);
 

--- a/lib/src/fields/defaults/number_field.dart
+++ b/lib/src/fields/defaults/number_field.dart
@@ -1,0 +1,47 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/src/utils/shared_messages.dart';
+import 'package:dart_json_schema_form/src/utils/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+class DjsfNumberField<T extends num> extends ReactiveFormField<T, T> {
+  final DjsfFieldContext ctx;
+  final bool obscureText;
+  final TextInputType? keyboardType;
+
+  DjsfNumberField({
+    required this.ctx,
+    required super.formControlName,
+    super.key,
+    this.obscureText = false,
+    this.keyboardType,
+  }) : super(
+          builder: (ReactiveFormFieldState<T, T> field) {
+            final title = ctx.propSchema['title'] as String? ?? ctx.path;
+            final ui = readUiFor(ctx.uiSchema, ctx.path);
+            final decoration = inputDecorationFromUi(title, ui);
+            final messages = messagesForField(ctx, ctx.path, ctx.propSchema);
+
+            // TODO Support sliders and updowns
+
+            return ReactiveTextField<T>(
+              formControl: field.control,
+              decoration: decoration,
+              obscureText: obscureText,
+              autofocus: ui.autofocus,
+              keyboardType: keyboardType ?? ui.keyboardTypeForString(),
+              autofillHints:
+                  ui.autocomplete != null ? [ui.autocomplete!] : null,
+              validationMessages: messages,
+              onChanged: (control) {
+                if ((control.value == null) && ui.emptyValue != null) {
+                  control.updateValue(ui.emptyValue as T);
+                }
+              },
+            );
+          },
+        );
+
+  @override
+  ReactiveFormFieldState<T, T> createState() => ReactiveFormFieldState<T, T>();
+}

--- a/lib/src/fields/defaults/number_field.dart
+++ b/lib/src/fields/defaults/number_field.dart
@@ -35,7 +35,7 @@ class DjsfNumberField<T extends num> extends ReactiveFormField<T, T> {
               validationMessages: messages,
               onChanged: (control) {
                 if ((control.value == null) && ui.emptyValue != null) {
-                  control.updateValue(ui.emptyValue as T);
+                  control.updateValue(ui.emptyValue as T, emitEvent: false);
                 }
               },
             );

--- a/lib/src/fields/defaults/text_field.dart
+++ b/lib/src/fields/defaults/text_field.dart
@@ -1,0 +1,45 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/src/utils/shared_messages.dart';
+import 'package:dart_json_schema_form/src/utils/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+class DjsfTextField<T> extends ReactiveFormField<T, T> {
+  final DjsfFieldContext ctx;
+  final bool obscureText;
+  final TextInputType? keyboardType;
+
+  DjsfTextField({
+    required this.ctx,
+    required super.formControlName,
+    super.key,
+    this.obscureText = false,
+    this.keyboardType,
+  }) : super(
+          builder: (ReactiveFormFieldState<T, T> field) {
+            final title = ctx.propSchema['title'] as String? ?? ctx.path;
+            final ui = readUiFor(ctx.uiSchema, ctx.path);
+            final decoration = inputDecorationFromUi(title, ui);
+            final messages = messagesForField(ctx, ctx.path, ctx.propSchema);
+
+            return ReactiveTextField<T>(
+              formControl: field.control,
+              decoration: decoration,
+              obscureText: obscureText,
+              autofocus: ui.autofocus,
+              keyboardType: keyboardType ?? ui.keyboardTypeForString(),
+              autofillHints:
+                  ui.autocomplete != null ? [ui.autocomplete!] : null,
+              validationMessages: messages,
+              onChanged: (control) {
+                if ((control.value == null) && ui.emptyValue != null) {
+                  control.updateValue(ui.emptyValue as T);
+                }
+              },
+            );
+          },
+        );
+
+  @override
+  ReactiveFormFieldState<T, T> createState() => ReactiveFormFieldState<T, T>();
+}

--- a/lib/src/fields/defaults/text_field.dart
+++ b/lib/src/fields/defaults/text_field.dart
@@ -18,7 +18,7 @@ class DjsfTextField<T> extends ReactiveFormField<T, T> {
   }) : super(
           builder: (ReactiveFormFieldState<T, T> field) {
             final title = ctx.propSchema['title'] as String? ?? ctx.path;
-            final ui = readUiFor(ctx.uiSchema, ctx.path);
+            final ui = readUiFor(ctx);
             final decoration = inputDecorationFromUi(title, ui);
             final messages = messagesForField(ctx, ctx.path, ctx.propSchema);
 

--- a/lib/src/fields/defaults/text_field.dart
+++ b/lib/src/fields/defaults/text_field.dart
@@ -32,7 +32,9 @@ class DjsfTextField<T> extends ReactiveFormField<T, T> {
                   ui.autocomplete != null ? [ui.autocomplete!] : null,
               validationMessages: messages,
               onChanged: (control) {
-                if ((control.value == null) && ui.emptyValue != null) {
+                if ((control.value == null ||
+                        control.value!.toString().isEmpty) &&
+                    ui.emptyValue != null) {
                   control.updateValue(ui.emptyValue as T);
                 }
               },

--- a/lib/src/fields/defaults/text_field.dart
+++ b/lib/src/fields/defaults/text_field.dart
@@ -29,13 +29,13 @@ class DjsfTextField<T> extends ReactiveFormField<T, T> {
               autofocus: ui.autofocus,
               keyboardType: keyboardType ?? ui.keyboardTypeForString(),
               autofillHints:
-                  ui.autocomplete != null ? [ui.autocomplete!] : null,
+                  autofillHints(ui.autocomplete) ?? autofillHints(ctx.path),
               validationMessages: messages,
               onChanged: (control) {
                 if ((control.value == null ||
                         control.value!.toString().isEmpty) &&
                     ui.emptyValue != null) {
-                  control.updateValue(ui.emptyValue as T);
+                  control.updateValue(ui.emptyValue as T, emitEvent: false);
                 }
               },
             );

--- a/lib/src/fields/defaults/textarea_field.dart
+++ b/lib/src/fields/defaults/textarea_field.dart
@@ -34,7 +34,10 @@ class DjsfTextAreaField extends ReactiveFormField<String, String> {
               maxLines: 4,
               onChanged: (control) {
                 if ((control.value == null) && ui.emptyValue != null) {
-                  control.updateValue(ui.emptyValue as String);
+                  control.updateValue(
+                    ui.emptyValue as String,
+                    emitEvent: false,
+                  );
                 }
               },
             );

--- a/lib/src/fields/defaults/textarea_field.dart
+++ b/lib/src/fields/defaults/textarea_field.dart
@@ -1,0 +1,47 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/src/utils/shared_messages.dart';
+import 'package:dart_json_schema_form/src/utils/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+class DjsfTextAreaField extends ReactiveFormField<String, String> {
+  final DjsfFieldContext ctx;
+  final bool obscureText;
+  final TextInputType? keyboardType;
+
+  DjsfTextAreaField({
+    required this.ctx,
+    required super.formControlName,
+    super.key,
+    this.obscureText = false,
+    this.keyboardType,
+  }) : super(
+          builder: (ReactiveFormFieldState<String, String> field) {
+            final title = ctx.propSchema['title'] as String? ?? ctx.path;
+            final ui = readUiFor(ctx.uiSchema, ctx.path);
+            final decoration = inputDecorationFromUi(title, ui);
+            final messages = messagesForField(ctx, ctx.path, ctx.propSchema);
+
+            return ReactiveTextField<String>(
+              formControl: field.control,
+              decoration: decoration,
+              obscureText: obscureText,
+              autofocus: ui.autofocus,
+              keyboardType: keyboardType ?? ui.keyboardTypeForString(),
+              autofillHints:
+                  ui.autocomplete != null ? [ui.autocomplete!] : null,
+              validationMessages: messages,
+              maxLines: 4,
+              onChanged: (control) {
+                if ((control.value == null) && ui.emptyValue != null) {
+                  control.updateValue(ui.emptyValue as String);
+                }
+              },
+            );
+          },
+        );
+
+  @override
+  ReactiveFormFieldState<String, String> createState() =>
+      ReactiveFormFieldState<String, String>();
+}

--- a/lib/src/fields/defaults/textarea_field.dart
+++ b/lib/src/fields/defaults/textarea_field.dart
@@ -18,7 +18,7 @@ class DjsfTextAreaField extends ReactiveFormField<String, String> {
   }) : super(
           builder: (ReactiveFormFieldState<String, String> field) {
             final title = ctx.propSchema['title'] as String? ?? ctx.path;
-            final ui = readUiFor(ctx.uiSchema, ctx.path);
+            final ui = readUiFor(ctx);
             final decoration = inputDecorationFromUi(title, ui);
             final messages = messagesForField(ctx, ctx.path, ctx.propSchema);
 

--- a/lib/src/fields/fields.dart
+++ b/lib/src/fields/fields.dart
@@ -1,0 +1,2 @@
+export 'registry.dart';
+export 'context.dart';

--- a/lib/src/fields/registry.dart
+++ b/lib/src/fields/registry.dart
@@ -1,0 +1,13 @@
+import 'package:dart_json_schema_form/src/types/types.dart';
+
+class DjsfFieldRegistry {
+  DjsfFieldRegistry(this.builders);
+
+  final Map<String, DjsfFieldBuilder> builders;
+
+  bool contains(String key) => builders.containsKey(key);
+  DjsfFieldBuilder? operator [](String key) => builders[key];
+
+  DjsfFieldRegistry merge(DjsfFieldRegistry other) =>
+      DjsfFieldRegistry({...builders, ...other.builders});
+}

--- a/lib/src/renderers/form_renderer.dart
+++ b/lib/src/renderers/form_renderer.dart
@@ -57,6 +57,7 @@ class FormRenderer extends StatelessWidget {
     debugPrint("Building with uiSchema: ${jsonEncode(ui)}");
 
     final ctx = DjsfFieldContext(
+      type: widgetKey,
       form: form,
       schema: schema,
       uiSchema: uiSchema,

--- a/lib/src/renderers/form_renderer.dart
+++ b/lib/src/renderers/form_renderer.dart
@@ -50,7 +50,8 @@ class FormRenderer extends StatelessWidget {
   ) {
     final type = (propSchema['type'] as String?) ?? 'string';
     final ui = uiSchema?[name] as JsonMap? ?? {};
-    final widgetKey = (ui['ui:widget'] as String?) ?? type;
+    final modifier = (ui['ui:options'] as JsonMap?)?['inputType'] as String?;
+    final widgetKey = modifier ?? (ui['ui:widget'] as String?) ?? type;
 
     debugPrint("Building $name with type $type and widgetKey $widgetKey");
     debugPrint("Building with uiSchema: ${jsonEncode(ui)}");

--- a/lib/src/renderers/form_renderer.dart
+++ b/lib/src/renderers/form_renderer.dart
@@ -1,6 +1,8 @@
+import 'dart:convert';
+
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/src/fields/defaults.dart';
 import 'package:dart_json_schema_form/src/i18n/bundles.dart';
-import 'package:dart_json_schema_form/src/types/djsf_error.dart';
-import 'package:dart_json_schema_form/src/types/types.dart';
 import 'package:flutter/material.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
@@ -9,168 +11,72 @@ class FormRenderer extends StatelessWidget {
   const FormRenderer({
     required this.form,
     required this.schema,
+    this.uiSchema,
     super.key,
-    this.transformErrors,
     this.messages = const IntlBundle(),
+    this.transformErrors,
+    this.fieldRegistry,
   });
 
   final FormGroup form;
   final JsonMap schema;
-  final TransformErrors? transformErrors;
+  final JsonMap? uiSchema;
   final DjsfMessageBundle messages;
+  final TransformErrors? transformErrors;
+  final DjsfFieldRegistry? fieldRegistry;
 
   @override
   Widget build(BuildContext context) {
     final rawProps = schema['properties'];
-
-    // Ensure properties exist and are valid
     if (rawProps == null || rawProps is! Map || rawProps.isEmpty) {
       return const SizedBox.shrink();
     }
-
     final properties = Map<String, dynamic>.from(rawProps);
+    final registry = fieldRegistry ?? defaultFieldRegistry();
 
     return Column(
       children: form.controls.entries.map((entry) {
         final name = entry.key;
         final propSchema = properties[name] as JsonMap? ?? {};
-        return _buildField(name, propSchema);
+        return _buildWithRegistry(name, propSchema, registry);
       }).toList(),
     );
   }
 
-  Widget _buildField(String name, JsonMap propSchema) {
-    final type = (propSchema['type'] as String?) ?? 'string';
-    final title = (propSchema['title'] as String?) ?? name;
-
-    switch (type) {
-      case 'integer':
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: ReactiveTextField<int>(
-            formControlName: name,
-            decoration: InputDecoration(labelText: title),
-            keyboardType: TextInputType.number,
-            validationMessages: _messagesForField(name, propSchema),
-          ),
-        );
-      case 'string':
-      default:
-        return Padding(
-          padding: const EdgeInsets.only(bottom: 12),
-          child: ReactiveTextField<String>(
-            formControlName: name,
-            decoration: InputDecoration(labelText: title),
-            validationMessages: _messagesForField(name, propSchema),
-          ),
-        );
-    }
-  }
-
-  /// Build messages for one field.
-  /// Returns a Map of validatorKey → ValidationMessageFunction
-  Map<String, ValidationMessageFunction> _messagesForField(
-    String fieldName,
-    JsonMap propSchema,
-  ) {
-    return {
-      ValidationMessage.required: (error) {
-        return _transformSingleError(
-          fieldName,
-          'required',
-          messages.required(),
-          propSchema,
-        );
-      },
-      ValidationMessage.minLength: (error) {
-        final limit = (propSchema['minLength'] is int)
-            ? propSchema['minLength'] as int
-            : 0;
-        return _transformSingleError(
-          fieldName,
-          'minLength',
-          messages.minLength(limit),
-          propSchema,
-          params: {'limit': limit},
-        );
-      },
-      ValidationMessage.maxLength: (error) {
-        final limit = (propSchema['maxLength'] is int)
-            ? propSchema['maxLength'] as int
-            : 0;
-        return _transformSingleError(
-          fieldName,
-          'maxLength',
-          messages.maxLength(limit),
-          propSchema,
-          params: {'limit': limit},
-        );
-      },
-      ValidationMessage.pattern: (error) {
-        return _transformSingleError(
-          fieldName,
-          'pattern',
-          messages.pattern(),
-          propSchema,
-          params: {'pattern': propSchema['pattern']},
-        );
-      },
-      ValidationMessage.min: (error) {
-        final limit = propSchema['minimum'];
-        final numLimit = (limit is num) ? limit : num.tryParse('$limit');
-        return _transformSingleError(
-          fieldName,
-          'min',
-          messages.min(numLimit ?? 0),
-          propSchema,
-          params: {'limit': numLimit},
-        );
-      },
-      ValidationMessage.max: (error) {
-        final limit = propSchema['maximum'];
-        final numLimit = (limit is num) ? limit : num.tryParse('$limit');
-        return _transformSingleError(
-          fieldName,
-          'max',
-          messages.max(numLimit ?? 0),
-          propSchema,
-          params: {'limit': numLimit},
-        );
-      },
-      ValidationMessage.equals: (error) {
-        final allowed = propSchema['const'];
-        return _transformSingleError(
-          fieldName,
-          'equals',
-          messages.equals(allowed),
-          propSchema,
-          params: {'allowed': allowed},
-        );
-      },
-    };
-  }
-
-  /// Apply transformErrors if provided
-  String _transformSingleError(
-    String fieldName,
+  Widget _buildWithRegistry(
     String name,
-    String defaultMessage,
-    JsonMap propSchema, {
-    Map<String, Object?>? params,
-  }) {
-    final error = DjsfError(
-      name: name,
-      property: '.$fieldName',
-      message: defaultMessage,
-      params: params,
+    JsonMap propSchema,
+    DjsfFieldRegistry registry,
+  ) {
+    final type = (propSchema['type'] as String?) ?? 'string';
+    final ui = uiSchema?[name] as JsonMap? ?? {};
+    final widgetKey = (ui['ui:widget'] as String?) ?? type;
+
+    debugPrint("Building $name with type $type and widgetKey $widgetKey");
+    debugPrint("Building with uiSchema: ${jsonEncode(ui)}");
+
+    final ctx = DjsfFieldContext(
+      form: form,
+      schema: schema,
+      uiSchema: uiSchema,
+      path: name,
+      propSchema: propSchema,
+      messages: messages,
+      transformErrors: transformErrors,
     );
 
-    if (transformErrors != null) {
-      final transformed = transformErrors!([error]);
-      if (transformed.isNotEmpty) {
-        return transformed.first.message;
-      }
+    final builder = registry[widgetKey] ?? registry[type] ?? registry['string'];
+
+    if (builder == null) {
+      return const SizedBox.shrink();
     }
-    return defaultMessage;
+
+    final field = builder(ctx);
+
+    // Wrap with padding or field container if desired
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: field,
+    );
   }
 }

--- a/lib/src/types/types.dart
+++ b/lib/src/types/types.dart
@@ -1,8 +1,12 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
 import 'package:dart_json_schema_form/src/types/djsf_error.dart';
+import 'package:reactive_forms/reactive_forms.dart';
 
 typedef JsonMap = Map<String, dynamic>;
 
 typedef TransformErrors = List<DjsfError> Function(List<DjsfError> errors);
+
+typedef DjsfFieldBuilder = ReactiveFormField Function(DjsfFieldContext ctx);
 
 /// Contract for a message bundle (could be backed by Intl or simple maps).
 abstract class DjsfMessageBundle {

--- a/lib/src/utils/shared_messages.dart
+++ b/lib/src/utils/shared_messages.dart
@@ -1,0 +1,127 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/src/types/djsf_error.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+/// Builds the validationMessages map for a field using the current i18n bundle
+/// and the optional RJSF-like transformErrors hook.
+///
+/// NOTE: reactive_forms (v17+) expects:
+///   [Map<String, ValidationMessageFunction>]
+/// where ValidationMessageFunction = String Function(Object error)
+Map<String, ValidationMessageFunction> messagesForField(
+  DjsfFieldContext ctx,
+  String fieldName,
+  JsonMap propSchema,
+) {
+  return {
+    ValidationMessage.required: (error) => _transformSingleError(
+          ctx,
+          fieldName,
+          'required',
+          ctx.messages.required(),
+          propSchema,
+        ),
+    ValidationMessage.minLength: (error) {
+      final limit = _asInt(propSchema['minLength']) ?? 0;
+      return _transformSingleError(
+        ctx,
+        fieldName,
+        'minLength',
+        ctx.messages.minLength(limit),
+        propSchema,
+        params: {'limit': limit},
+      );
+    },
+    ValidationMessage.maxLength: (error) {
+      final limit = _asInt(propSchema['maxLength']) ?? 0;
+      return _transformSingleError(
+        ctx,
+        fieldName,
+        'maxLength',
+        ctx.messages.maxLength(limit),
+        propSchema,
+        params: {'limit': limit},
+      );
+    },
+    ValidationMessage.pattern: (error) => _transformSingleError(
+          ctx,
+          fieldName,
+          'pattern',
+          ctx.messages.pattern(),
+          propSchema,
+          params: {'pattern': propSchema['pattern']},
+        ),
+    ValidationMessage.min: (error) {
+      final limit = _asNum(propSchema['minimum']) ?? 0;
+      return _transformSingleError(
+        ctx,
+        fieldName,
+        'min',
+        ctx.messages.min(limit),
+        propSchema,
+        params: {'limit': limit},
+      );
+    },
+    ValidationMessage.max: (error) {
+      final limit = _asNum(propSchema['maximum']) ?? 0;
+      return _transformSingleError(
+        ctx,
+        fieldName,
+        'max',
+        ctx.messages.max(limit),
+        propSchema,
+        params: {'limit': limit},
+      );
+    },
+    ValidationMessage.equals: (error) {
+      final allowed = propSchema['const'];
+      return _transformSingleError(
+        ctx,
+        fieldName,
+        'equals',
+        ctx.messages.equals(allowed),
+        propSchema,
+        params: {'allowed': allowed},
+      );
+    },
+  };
+}
+
+/// Applies the RJSF-like transformErrors (if provided) to a single error item
+/// and returns the final message to show.
+String _transformSingleError(
+  DjsfFieldContext ctx,
+  String fieldName,
+  String name,
+  String defaultMessage,
+  JsonMap propSchema, {
+  Map<String, Object?>? params,
+}) {
+  final error = DjsfError(
+    name: name,
+    property: '.$fieldName',
+    message: defaultMessage,
+    params: params,
+  );
+
+  if (ctx.transformErrors != null) {
+    final out = ctx.transformErrors!([error]);
+    if (out.isNotEmpty) {
+      return out.first.message;
+    }
+  }
+  return defaultMessage;
+}
+
+int? _asInt(dynamic v) {
+  if (v is int) return v;
+  if (v is num) return v.toInt();
+  if (v is String) return int.tryParse(v);
+  return null;
+}
+
+num? _asNum(dynamic v) {
+  if (v is num) return v;
+  if (v is String) return num.tryParse(v);
+  return null;
+}

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -1,0 +1,83 @@
+import 'package:dart_json_schema_form/src/types/types.dart';
+import 'package:flutter/material.dart';
+
+/// Parsed view of the uiSchema for a single field.
+class UiFieldConfig {
+  UiFieldConfig({
+    this.autofocus = false,
+    this.emptyValue,
+    this.placeholder,
+    this.autocomplete,
+    this.description,
+    this.inputType,
+  });
+
+  /// ui:autofocus
+  final bool autofocus;
+
+  /// ui:emptyValue
+  final dynamic emptyValue;
+
+  /// ui:placeholder
+  final String? placeholder;
+
+  /// ui:autocomplete (mapped to autofillHints)
+  final String? autocomplete;
+
+  /// ui:description (mapped to helperText)
+  final String? description;
+
+  /// ui:options.inputType (email|tel|url|number|password|textarea|...)
+  final String? inputType;
+
+  /// Heuristic: best keyboard type for string inputs based on inputType.
+  TextInputType? keyboardTypeForString() {
+    switch (inputType) {
+      case 'email':
+        return TextInputType.emailAddress;
+      case 'tel':
+      case 'phone':
+        return TextInputType.phone;
+      case 'url':
+        return TextInputType.url;
+      case 'number':
+        return TextInputType.number;
+      default:
+        return null;
+    }
+  }
+
+  /// Convenience flags.
+  bool get isPassword => inputType == 'password';
+  bool get isTextarea => inputType == 'textarea';
+}
+
+/// Reads uiSchema[name] and returns a normalized UiFieldConfig.
+/// Expects the whole uiSchema object and the field name.
+UiFieldConfig readUiFor(JsonMap? uiSchema, String fieldName) {
+  final raw = (uiSchema?[fieldName] is Map)
+      ? Map<String, dynamic>.from(uiSchema![fieldName] as Map)
+      : const <String, dynamic>{};
+
+  final options = (raw['ui:options'] is Map)
+      ? Map<String, dynamic>.from(raw['ui:options'] as Map)
+      : const <String, dynamic>{};
+
+  return UiFieldConfig(
+    autofocus: raw['ui:autofocus'] == true,
+    emptyValue: raw.containsKey('ui:emptyValue') ? raw['ui:emptyValue'] : null,
+    placeholder: raw['ui:placeholder'] as String?,
+    autocomplete: raw['ui:autocomplete'] as String?,
+    description: raw['ui:description'] as String?,
+    inputType: options['inputType'] as String?,
+  );
+}
+
+/// Builds an InputDecoration from label and UiFieldConfig.
+InputDecoration inputDecorationFromUi(String label, UiFieldConfig ui) {
+  return InputDecoration(
+    labelText: label,
+    hintText: ui.placeholder,
+    helperText: ui.description,
+  );
+}

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -45,6 +45,7 @@ class UiFieldConfig {
       case 'url':
         return TextInputType.url;
       case 'number':
+      case 'integer':
         return TextInputType.numberWithOptions(decimal: true);
       default:
         return null;
@@ -85,4 +86,20 @@ InputDecoration inputDecorationFromUi(String label, UiFieldConfig ui) {
     hintText: ui.hint,
     helperText: ui.helper,
   );
+}
+
+Iterable<String>? autofillHints(String? v) {
+  switch (v) {
+    case 'email':
+      return const [AutofillHints.email];
+    case 'name':
+      return const [AutofillHints.name];
+    case 'username':
+      return const [AutofillHints.username];
+    case 'tel':
+    case 'phone':
+      return const [AutofillHints.telephoneNumber];
+    default:
+      return v != null ? [v] : null;
+  }
 }

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -1,4 +1,4 @@
-import 'package:dart_json_schema_form/src/types/types.dart';
+import 'package:dart_json_schema_form/src/fields/context.dart';
 import 'package:flutter/material.dart';
 
 /// Parsed view of the uiSchema for a single field.
@@ -45,8 +45,9 @@ class UiFieldConfig {
       case 'url':
         return TextInputType.url;
       case 'number':
-      case 'integer':
         return TextInputType.numberWithOptions(decimal: true);
+      case 'integer':
+        return TextInputType.number;
       default:
         return null;
     }
@@ -59,13 +60,9 @@ class UiFieldConfig {
 
 /// Reads uiSchema[name] and returns a normalized UiFieldConfig.
 /// Expects the whole uiSchema object and the field name.
-UiFieldConfig readUiFor(JsonMap? uiSchema, String fieldName) {
-  final raw = (uiSchema?[fieldName] is Map)
-      ? Map<String, dynamic>.from(uiSchema![fieldName] as Map)
-      : const <String, dynamic>{};
-
-  final options = (raw['ui:options'] is Map)
-      ? Map<String, dynamic>.from(raw['ui:options'] as Map)
+UiFieldConfig readUiFor(DjsfFieldContext ctx) {
+  final raw = (ctx.uiSchema?[ctx.path] is Map)
+      ? Map<String, dynamic>.from(ctx.uiSchema?[ctx.path] as Map)
       : const <String, dynamic>{};
 
   return UiFieldConfig(
@@ -74,7 +71,7 @@ UiFieldConfig readUiFor(JsonMap? uiSchema, String fieldName) {
     hint: raw['ui:placeholder'] as String?,
     autocomplete: raw['ui:autocomplete'] as String?,
     description: raw['ui:description'] as String?,
-    inputType: options['inputType'] as String?,
+    inputType: ctx.type,
     helper: raw['ui:help'] as String?,
   );
 }

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -6,10 +6,11 @@ class UiFieldConfig {
   UiFieldConfig({
     this.autofocus = false,
     this.emptyValue,
-    this.placeholder,
+    this.hint,
     this.autocomplete,
     this.description,
     this.inputType,
+    this.helper,
   });
 
   /// ui:autofocus
@@ -19,7 +20,7 @@ class UiFieldConfig {
   final dynamic emptyValue;
 
   /// ui:placeholder
-  final String? placeholder;
+  final String? hint;
 
   /// ui:autocomplete (mapped to autofillHints)
   final String? autocomplete;
@@ -29,6 +30,9 @@ class UiFieldConfig {
 
   /// ui:options.inputType (email|tel|url|number|password|textarea|...)
   final String? inputType;
+
+  /// ui:help
+  final String? helper;
 
   /// Heuristic: best keyboard type for string inputs based on inputType.
   TextInputType? keyboardTypeForString() {
@@ -41,7 +45,7 @@ class UiFieldConfig {
       case 'url':
         return TextInputType.url;
       case 'number':
-        return TextInputType.number;
+        return TextInputType.numberWithOptions(decimal: true);
       default:
         return null;
     }
@@ -65,11 +69,12 @@ UiFieldConfig readUiFor(JsonMap? uiSchema, String fieldName) {
 
   return UiFieldConfig(
     autofocus: raw['ui:autofocus'] == true,
-    emptyValue: raw.containsKey('ui:emptyValue') ? raw['ui:emptyValue'] : null,
-    placeholder: raw['ui:placeholder'] as String?,
+    emptyValue: raw['ui:emptyValue'],
+    hint: raw['ui:placeholder'] as String?,
     autocomplete: raw['ui:autocomplete'] as String?,
     description: raw['ui:description'] as String?,
     inputType: options['inputType'] as String?,
+    helper: raw['ui:help'] as String?,
   );
 }
 
@@ -77,7 +82,7 @@ UiFieldConfig readUiFor(JsonMap? uiSchema, String fieldName) {
 InputDecoration inputDecorationFromUi(String label, UiFieldConfig ui) {
   return InputDecoration(
     labelText: label,
-    hintText: ui.placeholder,
-    helperText: ui.description,
+    hintText: ui.hint,
+    helperText: ui.helper,
   );
 }

--- a/test/fields/djsf_integer_field_test.dart
+++ b/test/fields/djsf_integer_field_test.dart
@@ -6,7 +6,7 @@ void main() {
   testWidgets('DjsfNumberField uses numeric keyboard', (tester) async {
     final schema = {
       'properties': {
-        'age': {'type': 'number', 'title': 'Age', 'minimum': 0},
+        'age': {'type': 'integer', 'title': 'Age', 'minimum': 0},
       },
     };
     final ui = {

--- a/test/fields/djsf_number_field_test.dart
+++ b/test/fields/djsf_number_field_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/src/fields/defaults/number_field.dart';
+
+import '../utils.dart';
+
+void main() {
+  testWidgets('DjsfNumberField uses numeric keyboard', (tester) async {
+    final form = FormGroup({'age': FormControl<int>()});
+    final schema = {
+      'properties': {
+        'age': {'type': 'integer', 'title': 'Age', 'minimum': 0},
+      },
+    };
+    final ui = {
+      'age': {
+        'ui:placeholder': 'Your age',
+        'ui:help': 'Must be at least 18',
+      },
+    };
+
+    final ctx = DjsfFieldContext(
+      form: form,
+      schema: schema,
+      uiSchema: ui,
+      path: 'age',
+      propSchema: schema['properties']?['age'] as Map<String, dynamic>,
+      messages: FakeBundle(),
+      transformErrors: null,
+    );
+
+    late TextInputType? effectiveKeyboardType;
+
+    // Wrap field to introspect the widget tree
+    final widget = MaterialApp(
+      home: Scaffold(
+        body: ReactiveForm(
+          formGroup: form,
+          child: Builder(
+            builder: (context) {
+              final field = DjsfNumberField<int>(
+                ctx: ctx,
+                formControlName: 'age',
+                keyboardType: TextInputType.number,
+              );
+              return field;
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpWidget(widget);
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    effectiveKeyboardType = textField.keyboardType;
+
+    // Expect numeric keyboard
+    expect(effectiveKeyboardType, isNotNull);
+    expect(
+      effectiveKeyboardType.index,
+      equals(TextInputType.number.index),
+      reason:
+          'DjsfNumberField should default to a numeric keyboard (TextInputType.number)',
+    );
+
+    // Placeholder + helper are visible via InputDecoration
+    expect(find.text('Your age'), findsOneWidget);
+    expect(find.text('Must be at least 18'), findsOneWidget);
+  });
+}

--- a/test/fields/djsf_password_field_test.dart
+++ b/test/fields/djsf_password_field_test.dart
@@ -1,0 +1,41 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('DjsfTextField on password renders with obscure true',
+      (tester) async {
+    final schema = {
+      'properties': {
+        'password': {'type': 'string', 'title': 'Password'},
+      },
+    };
+    final ui = {
+      "password": {"ui:widget": "password", "ui:help": "Make it strong"},
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DjsfForm(
+            schema: schema,
+            uiSchema: ui,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Placeholder + helper are visible via InputDecoration
+    expect(find.text('Password'), findsOneWidget);
+    expect(find.text('Make it strong'), findsOneWidget);
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    final obscure = textField.obscureText;
+
+    // Expect numeric keyboard
+    expect(obscure, isNotNull);
+    expect(obscure, isTrue);
+  });
+}

--- a/test/fields/djsf_text_area_field_test.dart
+++ b/test/fields/djsf_text_area_field_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/src/fields/defaults/textarea_field.dart';
+
+import '../utils.dart';
+
+void main() {
+  testWidgets('DjsfTextAreaField renders multiline', (tester) async {
+    final form = FormGroup({'bio': FormControl<String>()});
+    final schema = {
+      'properties': {
+        'bio': {'type': 'string', 'title': 'Bio'},
+      },
+    };
+    final ui = {
+      'bio': {
+        'ui:options': {'inputType': 'textarea'},
+        'ui:placeholder': 'Your bio',
+        'ui:help': 'Tell us about you',
+      },
+    };
+
+    final ctx = DjsfFieldContext(
+      form: form,
+      schema: schema,
+      uiSchema: ui,
+      path: 'bio',
+      propSchema: schema['properties']?['bio'] as Map<String, dynamic>,
+      messages: FakeBundle(),
+      transformErrors: null,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ReactiveForm(
+            formGroup: form,
+            child: DjsfTextAreaField(
+              ctx: ctx,
+              formControlName: 'bio',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    // maxLines configured in your implementation (4)
+    expect(textField.maxLines, equals(4));
+
+    // Placeholder + helper are visible via InputDecoration
+    expect(find.text('Your bio'), findsOneWidget);
+    expect(find.text('Tell us about you'), findsOneWidget);
+  });
+}

--- a/test/fields/djsf_text_area_field_test.dart
+++ b/test/fields/djsf_text_area_field_test.dart
@@ -1,14 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:reactive_forms/reactive_forms.dart';
 import 'package:dart_json_schema_form/dart_json_schema_form.dart';
-import 'package:dart_json_schema_form/src/fields/defaults/textarea_field.dart';
-
-import '../utils.dart';
 
 void main() {
   testWidgets('DjsfTextAreaField renders multiline', (tester) async {
-    final form = FormGroup({'bio': FormControl<String>()});
     final schema = {
       'properties': {
         'bio': {'type': 'string', 'title': 'Bio'},
@@ -16,35 +11,25 @@ void main() {
     };
     final ui = {
       'bio': {
+        'ui:widget': 'textarea',
         'ui:options': {'inputType': 'textarea'},
         'ui:placeholder': 'Your bio',
         'ui:help': 'Tell us about you',
       },
     };
 
-    final ctx = DjsfFieldContext(
-      form: form,
-      schema: schema,
-      uiSchema: ui,
-      path: 'bio',
-      propSchema: schema['properties']?['bio'] as Map<String, dynamic>,
-      messages: FakeBundle(),
-      transformErrors: null,
-    );
-
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: ReactiveForm(
-            formGroup: form,
-            child: DjsfTextAreaField(
-              ctx: ctx,
-              formControlName: 'bio',
-            ),
+          body: DjsfForm(
+            schema: schema,
+            uiSchema: ui,
           ),
         ),
       ),
     );
+
+    await tester.pumpAndSettle();
 
     final textField = tester.widget<TextField>(find.byType(TextField));
     // maxLines configured in your implementation (4)

--- a/test/fields/djsf_text_field_test.dart
+++ b/test/fields/djsf_text_field_test.dart
@@ -1,14 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:reactive_forms/reactive_forms.dart';
 import 'package:dart_json_schema_form/dart_json_schema_form.dart';
-import 'package:dart_json_schema_form/src/fields/defaults/text_field.dart';
-
-import '../utils.dart';
 
 void main() {
-  testWidgets('DjsfTextField renders hint/help', (tester) async {
-    final form = FormGroup({'name': FormControl<String>()});
+  testWidgets('DjsfTextField renders for string', (tester) async {
     final schema = {
       'properties': {
         'name': {'type': 'string', 'title': 'Name'},
@@ -22,32 +17,139 @@ void main() {
       },
     };
 
-    final ctx = DjsfFieldContext(
-      form: form,
-      schema: schema,
-      uiSchema: ui,
-      path: 'name',
-      propSchema: schema['properties']?['name'] as Map<String, dynamic>,
-      messages: FakeBundle(),
-      transformErrors: null,
-    );
-
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
-          body: ReactiveForm(
-            formGroup: form,
-            child: DjsfTextField<String>(
-              ctx: ctx,
-              formControlName: 'name',
-            ),
+          body: DjsfForm(
+            schema: schema,
+            uiSchema: ui,
           ),
         ),
       ),
     );
 
+    await tester.pumpAndSettle();
+
     // Placeholder + helper are visible via InputDecoration
     expect(find.text('Full name'), findsOneWidget);
     expect(find.text('At least 2 words'), findsOneWidget);
+  });
+
+  testWidgets('DjsfTextField renders for text', (tester) async {
+    final schema = {
+      'properties': {
+        'name': {'type': 'string', 'title': 'Name'},
+      },
+    };
+    final ui = {
+      'name': {
+        'ui:widget': 'text',
+        'ui:placeholder': 'Full name',
+        'ui:help': 'At least 2 words',
+        'ui:emptyValue': 'N/A',
+      },
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DjsfForm(
+            schema: schema,
+            uiSchema: ui,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Placeholder + helper are visible via InputDecoration
+    expect(find.text('Full name'), findsOneWidget);
+    expect(find.text('At least 2 words'), findsOneWidget);
+  });
+
+  testWidgets('DjsfTextField renders for email', (tester) async {
+    final schema = {
+      'properties': {
+        'email': {'type': 'string', 'title': 'Email'},
+      },
+    };
+    final ui = {
+      'email': {
+        "ui:options": {"inputType": "email"},
+        'ui:placeholder': 'Email address',
+        'ui:help': 'example@domain.com',
+      },
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DjsfForm(
+            schema: schema,
+            uiSchema: ui,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Placeholder + helper are visible via InputDecoration
+    expect(find.text('Email address'), findsOneWidget);
+    expect(find.text('example@domain.com'), findsOneWidget);
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    final effectiveKeyboardType = textField.keyboardType;
+
+    // Expect phone keyboard
+    expect(effectiveKeyboardType, isNotNull);
+    expect(
+      effectiveKeyboardType.index,
+      equals(TextInputType.emailAddress.index),
+    );
+  });
+
+  testWidgets('DjsfTextField renders for phone', (tester) async {
+    final schema = {
+      'properties': {
+        'telephone': {'type': 'string', 'title': 'Name'},
+      },
+    };
+    final ui = {
+      'telephone': {
+        "ui:options": {"inputType": "tel"},
+        'ui:placeholder': 'Your telephone',
+        'ui:help': '+123456789',
+        'ui:emptyValue': 'N/A',
+      },
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: DjsfForm(
+            schema: schema,
+            uiSchema: ui,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    // Placeholder + helper are visible via InputDecoration
+    expect(find.text('Your telephone'), findsOneWidget);
+    expect(find.text('+123456789'), findsOneWidget);
+
+    final textField = tester.widget<TextField>(find.byType(TextField));
+    final effectiveKeyboardType = textField.keyboardType;
+
+    // Expect phone keyboard
+    expect(effectiveKeyboardType, isNotNull);
+    expect(
+      effectiveKeyboardType.index,
+      equals(TextInputType.phone.index),
+    );
   });
 }

--- a/test/fields/djsf_text_field_test.dart
+++ b/test/fields/djsf_text_field_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/src/fields/defaults/text_field.dart';
+
+import '../utils.dart';
+
+void main() {
+  testWidgets('DjsfTextField renders hint/help', (tester) async {
+    final form = FormGroup({'name': FormControl<String>()});
+    final schema = {
+      'properties': {
+        'name': {'type': 'string', 'title': 'Name'},
+      },
+    };
+    final ui = {
+      'name': {
+        'ui:placeholder': 'Full name',
+        'ui:help': 'At least 2 words',
+        'ui:emptyValue': 'N/A',
+      },
+    };
+
+    final ctx = DjsfFieldContext(
+      form: form,
+      schema: schema,
+      uiSchema: ui,
+      path: 'name',
+      propSchema: schema['properties']?['name'] as Map<String, dynamic>,
+      messages: FakeBundle(),
+      transformErrors: null,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ReactiveForm(
+            formGroup: form,
+            child: DjsfTextField<String>(
+              ctx: ctx,
+              formControlName: 'name',
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Placeholder + helper are visible via InputDecoration
+    expect(find.text('Full name'), findsOneWidget);
+    expect(find.text('At least 2 words'), findsOneWidget);
+  });
+}

--- a/test/i18n/i18n_required_message_test.dart
+++ b/test/i18n/i18n_required_message_test.dart
@@ -17,22 +17,22 @@ Widget _app(Locale locale) {
       "minLengthMessage": {
         "type": "string",
         "title": "Min Length Field",
-        "minLength": 5
+        "minLength": 5,
       },
       "maxLengthMessage": {
         "type": "string",
         "title": "Max Length Field",
-        "maxLength": 5
+        "maxLength": 5,
       },
       "minimumMessage": {
         "type": "integer",
         "title": "Minimum Field",
-        "minimum": 2
+        "minimum": 2,
       },
       "maximumMessage": {
         "type": "integer",
         "title": "Maximum Field",
-        "maximum": 2
+        "maximum": 2,
       },
       "patternMessage": {
         "type": "string",
@@ -107,42 +107,54 @@ void main() {
 
       // 2) MIN LENGTH (Min Length Field, minLength=5): enter "abc" (3 chars)
       await tester.enterText(
-          await _textFieldByLabel(tester, 'Min Length Field'), 'abc');
+        await _textFieldByLabel(tester, 'Min Length Field'),
+        'abc',
+      );
       await tapButton(tester);
       await tester.pumpAndSettle();
       expect(find.text(minLengthMsg5), findsOneWidget);
 
       // 3) MAX LENGTH (Max Length Field, maxLength=5): enter 10 chars
       await tester.enterText(
-          await _textFieldByLabel(tester, 'Max Length Field'), 'abcdefghij');
+        await _textFieldByLabel(tester, 'Max Length Field'),
+        'abcdefghij',
+      );
       await tapButton(tester);
       await tester.pumpAndSettle();
       expect(find.text(maxLengthMsg5), findsOneWidget);
 
       // 4) PATTERN (Pattern Field expects email): enter "nope"
       await tester.enterText(
-          await _textFieldByLabel(tester, 'Pattern Field'), 'nope');
+        await _textFieldByLabel(tester, 'Pattern Field'),
+        'nope',
+      );
       await tapButton(tester);
       await tester.pumpAndSettle();
       expect(find.text(patternMsg), findsOneWidget);
 
       // 5) MINIMUM (Minimum Field, minimum=2): enter "1"
       await tester.enterText(
-          await _textFieldByLabel(tester, 'Minimum Field'), '1');
+        await _textFieldByLabel(tester, 'Minimum Field'),
+        '1',
+      );
       await tapButton(tester);
       await tester.pumpAndSettle();
       expect(find.text(minMsg2), findsOneWidget);
 
       // 6) MAXIMUM (Maximum Field, maximum=2): enter "3"
       await tester.enterText(
-          await _textFieldByLabel(tester, 'Maximum Field'), '3');
+        await _textFieldByLabel(tester, 'Maximum Field'),
+        '3',
+      );
       await tapButton(tester);
       await tester.pumpAndSettle();
       expect(find.text(maxMsg2), findsOneWidget);
 
       // 7) CONST/EQUALS (Equals Field, const=2): enter "4"
       await tester.enterText(
-          await _textFieldByLabel(tester, 'Equals Field'), '4');
+        await _textFieldByLabel(tester, 'Equals Field'),
+        '4',
+      );
       await tapButton(tester);
       await tester.pumpAndSettle();
       expect(find.text(equalsMsg2), findsOneWidget);

--- a/test/i18n/i18n_required_message_test.dart
+++ b/test/i18n/i18n_required_message_test.dart
@@ -1,17 +1,50 @@
 // example/test/i18n_required_message_test.dart
-import 'package:dart_json_schema_form/src/i18n/bundles.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:dart_json_schema_form/dart_json_schema_form.dart';
 import 'package:dart_json_schema_form/generated/l10n.dart' as djsf_l10n;
+import 'package:dart_json_schema_form/src/i18n/bundles.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
 
+/// Build a test app with a schema that exercises ALL validators.
 Widget _app(Locale locale) {
   final schema = {
     "title": "Form",
-    "required": ["username"],
+    // Make a real required field
+    "required": ["requiredMessage"],
     "properties": {
-      "username": {"type": "string", "title": "Username", "minLength": 5},
+      "requiredMessage": {"type": "string", "title": "Required Field"},
+      "minLengthMessage": {
+        "type": "string",
+        "title": "Min Length Field",
+        "minLength": 5
+      },
+      "maxLengthMessage": {
+        "type": "string",
+        "title": "Max Length Field",
+        "maxLength": 5
+      },
+      "minimumMessage": {
+        "type": "integer",
+        "title": "Minimum Field",
+        "minimum": 2
+      },
+      "maximumMessage": {
+        "type": "integer",
+        "title": "Maximum Field",
+        "maximum": 2
+      },
+      "patternMessage": {
+        "type": "string",
+        "title": "Pattern Field",
+        "pattern": r"^[^\s@]+@[^\s@]+\.[^\s@]+$",
+      },
+      "equalsMessage": {
+        "type": "integer",
+        "title": "Equals Field",
+        // our parser supports JSON Schema 'const'
+        "const": 2,
+      },
     },
   };
 
@@ -25,34 +58,122 @@ Widget _app(Locale locale) {
     ],
     supportedLocales: djsf_l10n.S.delegate.supportedLocales,
     home: Scaffold(
-      body: DjsfForm(
-        schema: schema,
-        messagesBundle: IntlBundle(),
+      body: Padding(
+        padding: const EdgeInsets.all(8),
+        child: DjsfForm(
+          schema: schema,
+          messagesBundle: const IntlBundle(),
+        ),
       ),
     ),
   );
 }
 
+/// Helper: find the TextField whose decoration.labelText == [label]
+Future<Finder> _textFieldByLabel(WidgetTester tester, String label) async {
+  final finder = find.byWidgetPredicate(
+    (w) => w is TextField && (w.decoration?.labelText == label),
+    description: 'TextField(labelText="$label")',
+  );
+  await tester.ensureVisible(finder);
+  return finder;
+}
+
+Future<void> tapButton(WidgetTester tester) async {
+  await tester.ensureVisible(find.text('Submit'));
+  await tester.tap(find.text('Submit'));
+}
+
 void main() {
-  testWidgets('required message shows in English', (tester) async {
-    await tester.pumpWidget(_app(const Locale('en')));
-    await tester.pumpAndSettle();
+  group('IntlBundle validation messages', () {
+    Future<void> runAllValidatorAssertions(
+      WidgetTester tester, {
+      required Locale locale,
+      required String requiredMsg,
+      required String minLengthMsg5,
+      required String maxLengthMsg5,
+      required String patternMsg,
+      required String minMsg2,
+      required String maxMsg2,
+      required String equalsMsg2,
+    }) async {
+      await tester.pumpWidget(_app(locale));
+      await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Submit'));
-    await tester.pumpAndSettle();
+      // 1) REQUIRED (Required Field): press submit to show message
+      await tapButton(tester);
+      await tester.pumpAndSettle();
+      expect(find.text(requiredMsg), findsOneWidget);
 
-    // From intl_en.arb
-    expect(find.text('This field is required'), findsOneWidget);
-  });
+      // 2) MIN LENGTH (Min Length Field, minLength=5): enter "abc" (3 chars)
+      await tester.enterText(
+          await _textFieldByLabel(tester, 'Min Length Field'), 'abc');
+      await tapButton(tester);
+      await tester.pumpAndSettle();
+      expect(find.text(minLengthMsg5), findsOneWidget);
 
-  testWidgets('required message shows in Spanish', (tester) async {
-    await tester.pumpWidget(_app(const Locale('es')));
-    await tester.pumpAndSettle();
+      // 3) MAX LENGTH (Max Length Field, maxLength=5): enter 10 chars
+      await tester.enterText(
+          await _textFieldByLabel(tester, 'Max Length Field'), 'abcdefghij');
+      await tapButton(tester);
+      await tester.pumpAndSettle();
+      expect(find.text(maxLengthMsg5), findsOneWidget);
 
-    await tester.tap(find.text('Submit'));
-    await tester.pumpAndSettle();
+      // 4) PATTERN (Pattern Field expects email): enter "nope"
+      await tester.enterText(
+          await _textFieldByLabel(tester, 'Pattern Field'), 'nope');
+      await tapButton(tester);
+      await tester.pumpAndSettle();
+      expect(find.text(patternMsg), findsOneWidget);
 
-    // From intl_es.arb
-    expect(find.text('Este campo es obligatorio'), findsOneWidget);
+      // 5) MINIMUM (Minimum Field, minimum=2): enter "1"
+      await tester.enterText(
+          await _textFieldByLabel(tester, 'Minimum Field'), '1');
+      await tapButton(tester);
+      await tester.pumpAndSettle();
+      expect(find.text(minMsg2), findsOneWidget);
+
+      // 6) MAXIMUM (Maximum Field, maximum=2): enter "3"
+      await tester.enterText(
+          await _textFieldByLabel(tester, 'Maximum Field'), '3');
+      await tapButton(tester);
+      await tester.pumpAndSettle();
+      expect(find.text(maxMsg2), findsOneWidget);
+
+      // 7) CONST/EQUALS (Equals Field, const=2): enter "4"
+      await tester.enterText(
+          await _textFieldByLabel(tester, 'Equals Field'), '4');
+      await tapButton(tester);
+      await tester.pumpAndSettle();
+      expect(find.text(equalsMsg2), findsOneWidget);
+    }
+
+    testWidgets('shows all validator messages in English', (tester) async {
+      await runAllValidatorAssertions(
+        tester,
+        locale: const Locale('en'),
+        requiredMsg: 'This field is required',
+        minLengthMsg5: 'Must be at least 5 characters',
+        maxLengthMsg5: 'Must be at most 5 characters',
+        patternMsg: 'Invalid format',
+        minMsg2: 'Must be ≥ 2',
+        maxMsg2: 'Must be ≤ 2',
+        equalsMsg2: 'Must equal 2',
+      );
+    });
+
+    testWidgets('shows all validator messages in Spanish', (tester) async {
+      await runAllValidatorAssertions(
+        tester,
+        locale: const Locale('es'),
+        requiredMsg: 'Este campo es obligatorio',
+        minLengthMsg5: 'Debe tener al menos 5 caracteres',
+        maxLengthMsg5: 'Debe tener como máximo 5 caracteres',
+        patternMsg: 'Formato inválido',
+        minMsg2: 'Debe ser ≥ 2',
+        maxMsg2: 'Debe ser ≤ 2',
+        equalsMsg2: 'Debe ser igual a 2',
+      );
+    });
   });
 }

--- a/test/renderers/form_renderer_registry_resolution_test.dart
+++ b/test/renderers/form_renderer_registry_resolution_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/src/renderers/form_renderer.dart';
+import 'package:dart_json_schema_form/src/fields/registry.dart';
+
+import '../utils.dart';
+
+void main() {
+  testWidgets(
+      'FormRenderer resolves builder by ui:options.inputType, ui:widget, or type',
+      (tester) async {
+    final form = FormGroup({
+      'email': FormControl<String>(),
+      'pwd': FormControl<String>(),
+      'age': FormControl<int>(),
+    });
+
+    final schema = {
+      'properties': {
+        'email': {'type': 'string', 'title': 'Email'},
+        'pwd': {'type': 'string', 'title': 'Password'},
+        'age': {'type': 'integer', 'title': 'Age'},
+      },
+    };
+
+    final uiSchema = {
+      'email': {
+        'ui:options': {'inputType': 'email'},
+      },
+      'pwd': {
+        'ui:widget': 'password',
+      },
+      // age resolves by its type = integer
+    };
+
+    // Spy registry: record keys used
+    final usedKeys = <String>[];
+    final spyRegistry = DjsfFieldRegistry({
+      'email': (ctx) {
+        usedKeys.add('email');
+        return ReactiveTextField<String>(formControlName: ctx.path);
+      },
+      'password': (ctx) {
+        usedKeys.add('password');
+        return ReactiveTextField<String>(
+          formControlName: ctx.path,
+          obscureText: true,
+        );
+      },
+      'integer': (ctx) {
+        usedKeys.add('integer');
+        return ReactiveTextField<int>(formControlName: ctx.path);
+      },
+      'string': (ctx) {
+        usedKeys.add('string');
+        return ReactiveTextField<String>(formControlName: ctx.path);
+      },
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ReactiveForm(
+            formGroup: form,
+            child: FormRenderer(
+              form: form,
+              schema: schema,
+              uiSchema: uiSchema,
+              messages: FakeBundle(),
+              fieldRegistry: spyRegistry,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // All three fields are built:
+    expect(find.byType(TextField), findsNWidgets(3));
+
+    // Resolution order asserts:
+    expect(
+      usedKeys.contains('email'),
+      isTrue,
+      reason: 'email should be resolved via ui:options.inputType=email',
+    );
+    expect(
+      usedKeys.contains('password'),
+      isTrue,
+      reason: 'pwd should resolve via ui:widget=password',
+    );
+    expect(
+      usedKeys.contains('integer'),
+      isTrue,
+      reason: 'age should resolve via type=integer',
+    );
+  });
+}

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,0 +1,18 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+
+class FakeBundle implements DjsfMessageBundle {
+  @override
+  String equals(allowed) => 'eq';
+  @override
+  String max(num limit) => 'max';
+  @override
+  String min(num limit) => 'min';
+  @override
+  String maxLength(int limit) => 'maxlen';
+  @override
+  String minLength(int limit) => 'minlen';
+  @override
+  String pattern() => 'pattern';
+  @override
+  String required() => 'required';
+}

--- a/test/utils/shared_messages_test.dart
+++ b/test/utils/shared_messages_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+import 'package:dart_json_schema_form/src/utils/shared_messages.dart';
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+
+// Fake bundle to make messages deterministic
+class _FakeBundle implements DjsfMessageBundle {
+  @override
+  String equals(allowed) => 'EQ $allowed';
+  @override
+  String max(num limit) => 'MAX $limit';
+  @override
+  String min(num limit) => 'MIN $limit';
+  @override
+  String maxLength(int limit) => 'MAXLEN $limit';
+  @override
+  String minLength(int limit) => 'MINLEN $limit';
+  @override
+  String pattern() => 'PATTERN';
+  @override
+  String required() => 'REQUIRED';
+}
+
+void main() {
+  group('messagesForField', () {
+    DjsfFieldContext ctx0({TransformErrors? transform}) {
+      final form = FormGroup({
+        'f': FormControl<String>(
+            validators: [Validators.required, Validators.minLength(3)])
+      });
+      final schema = {
+        'properties': {
+          'f': {'type': 'string', 'title': 'F', 'minLength': 3}
+        }
+      };
+      return DjsfFieldContext(
+        form: form,
+        schema: schema,
+        uiSchema: const {},
+        path: 'f',
+        propSchema: schema['properties']?['f'] as Map<String, dynamic>,
+        messages: _FakeBundle(),
+        transformErrors: transform,
+      );
+    }
+
+    test('returns default bundle messages', () {
+      final ctx = ctx0();
+      final map = messagesForField(ctx, 'f', ctx.propSchema);
+
+      expect(map.containsKey(ValidationMessage.required), isTrue);
+      expect(map.containsKey(ValidationMessage.minLength), isTrue);
+
+      // Call functions to get strings
+      final reqMsg = map[ValidationMessage.required]!.call({});
+      final minLenMsg = map[ValidationMessage.minLength]!.call({});
+
+      expect(reqMsg, equals('REQUIRED'));
+      expect(minLenMsg, equals('MINLEN 3'));
+    });
+
+    test('transformErrors overrides messages', () {
+      final ctx = ctx0(transform: (errors) {
+        return errors.map((e) {
+          if (e.name == 'required' && e.property == '.f') {
+            e.message = 'CUSTOM REQUIRED';
+          }
+          if (e.name == 'minLength') {
+            e.message = 'CUSTOM MINLEN';
+          }
+          return e;
+        }).toList();
+      });
+
+      final map = messagesForField(ctx, 'f', ctx.propSchema);
+      expect(
+          map[ValidationMessage.required]!.call({}), equals('CUSTOM REQUIRED'));
+      expect(
+          map[ValidationMessage.minLength]!.call({}), equals('CUSTOM MINLEN'));
+    });
+  });
+}

--- a/test/utils/shared_messages_test.dart
+++ b/test/utils/shared_messages_test.dart
@@ -26,14 +26,16 @@ void main() {
     DjsfFieldContext ctx0({TransformErrors? transform}) {
       final form = FormGroup({
         'f': FormControl<String>(
-            validators: [Validators.required, Validators.minLength(3)])
+          validators: [Validators.required, Validators.minLength(3)],
+        ),
       });
       final schema = {
         'properties': {
-          'f': {'type': 'string', 'title': 'F', 'minLength': 3}
-        }
+          'f': {'type': 'string', 'title': 'F', 'minLength': 3},
+        },
       };
       return DjsfFieldContext(
+        type: 'string',
         form: form,
         schema: schema,
         uiSchema: const {},
@@ -60,23 +62,29 @@ void main() {
     });
 
     test('transformErrors overrides messages', () {
-      final ctx = ctx0(transform: (errors) {
-        return errors.map((e) {
-          if (e.name == 'required' && e.property == '.f') {
-            e.message = 'CUSTOM REQUIRED';
-          }
-          if (e.name == 'minLength') {
-            e.message = 'CUSTOM MINLEN';
-          }
-          return e;
-        }).toList();
-      });
+      final ctx = ctx0(
+        transform: (errors) {
+          return errors.map((e) {
+            if (e.name == 'required' && e.property == '.f') {
+              e.message = 'CUSTOM REQUIRED';
+            }
+            if (e.name == 'minLength') {
+              e.message = 'CUSTOM MINLEN';
+            }
+            return e;
+          }).toList();
+        },
+      );
 
       final map = messagesForField(ctx, 'f', ctx.propSchema);
       expect(
-          map[ValidationMessage.required]!.call({}), equals('CUSTOM REQUIRED'));
+        map[ValidationMessage.required]!.call({}),
+        equals('CUSTOM REQUIRED'),
+      );
       expect(
-          map[ValidationMessage.minLength]!.call({}), equals('CUSTOM MINLEN'));
+        map[ValidationMessage.minLength]!.call({}),
+        equals('CUSTOM MINLEN'),
+      );
     });
   });
 }

--- a/test/utils/ui_utils_test.dart
+++ b/test/utils/ui_utils_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_json_schema_form/src/utils/utils.dart';
+
+void main() {
+  group('Ui utils', () {
+    test('readUiFor parses uiSchema correctly', () {
+      final uiSchema = {
+        'email': {
+          'ui:autofocus': true,
+          'ui:emptyValue': '',
+          'ui:placeholder': 'Enter email',
+          'ui:autocomplete': 'email',
+          'ui:description': 'We never share it',
+          'ui:help': 'Use a valid email',
+          'ui:options': {'inputType': 'email'},
+        },
+      };
+
+      final ui = readUiFor(uiSchema, 'email');
+      expect(ui.autofocus, isTrue);
+      expect(ui.emptyValue, equals(''));
+      expect(ui.hint, equals('Enter email'));
+      expect(ui.autocomplete, equals('email'));
+      expect(ui.description, equals('We never share it'));
+      expect(ui.helper, equals('Use a valid email'));
+      expect(ui.inputType, equals('email'));
+      expect(ui.isPassword, isFalse);
+      expect(ui.isTextarea, isFalse);
+
+      // keyboardType inferred from inputType
+      expect(ui.keyboardTypeForString(), equals(TextInputType.emailAddress));
+    });
+
+    test('password and textarea flags', () {
+      final uiPassword = readUiFor(
+        {
+          'pwd': {
+            'ui:options': {'inputType': 'password'},
+          },
+        },
+        'pwd',
+      );
+      expect(uiPassword.isPassword, isTrue);
+      expect(uiPassword.isTextarea, isFalse);
+
+      final uiTextarea = readUiFor(
+        {
+          'bio': {
+            'ui:options': {'inputType': 'textarea'},
+          },
+        },
+        'bio',
+      );
+      expect(uiTextarea.isTextarea, isTrue);
+      expect(uiTextarea.isPassword, isFalse);
+      expect(
+        uiTextarea.keyboardTypeForString(),
+        isNull,
+      ); // default for textarea
+    });
+
+    test('inputDecorationFromUi applies hint/help', () {
+      final ui = readUiFor(
+        {
+          'name': {
+            'ui:placeholder': 'Full name',
+            'ui:help': 'At least 2 words',
+          },
+        },
+        'name',
+      );
+
+      final dec = inputDecorationFromUi('Name', ui);
+      expect(dec.labelText, equals('Name'));
+      expect(dec.hintText, equals('Full name'));
+      expect(dec.helperText, equals('At least 2 words'));
+    });
+  });
+}

--- a/test/utils/ui_utils_test.dart
+++ b/test/utils/ui_utils_test.dart
@@ -1,10 +1,22 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/src/i18n/bundles.dart';
+import 'package:dart_json_schema_form/src/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:dart_json_schema_form/src/utils/utils.dart';
+import 'package:reactive_forms/reactive_forms.dart';
 
 void main() {
   group('Ui utils', () {
     test('readUiFor parses uiSchema correctly', () {
+      final schema = <String, dynamic>{
+        'type': 'object',
+        'properties': <String, dynamic>{
+          'email': {
+            'type': 'string',
+          },
+        },
+      };
+
       final uiSchema = {
         'email': {
           'ui:autofocus': true,
@@ -17,7 +29,21 @@ void main() {
         },
       };
 
-      final ui = readUiFor(uiSchema, 'email');
+      final form = FormGroup({
+        'email': FormControl<String>(),
+      });
+
+      final ctx = DjsfFieldContext(
+        type: 'email',
+        form: form,
+        schema: schema,
+        uiSchema: uiSchema,
+        path: 'email',
+        propSchema: (schema['properties']! as JsonMap)['email'] as JsonMap,
+        messages: IntlBundle(),
+      );
+
+      final ui = readUiFor(ctx);
       expect(ui.autofocus, isTrue);
       expect(ui.emptyValue, equals(''));
       expect(ui.hint, equals('Enter email'));
@@ -32,44 +58,113 @@ void main() {
       expect(ui.keyboardTypeForString(), equals(TextInputType.emailAddress));
     });
 
-    test('password and textarea flags', () {
-      final uiPassword = readUiFor(
-        {
+    test('password flags', () {
+      final schema = <String, dynamic>{
+        'type': 'object',
+        'properties': <String, dynamic>{
           'pwd': {
-            'ui:options': {'inputType': 'password'},
+            'type': 'string',
           },
         },
-        'pwd',
-      );
-      expect(uiPassword.isPassword, isTrue);
-      expect(uiPassword.isTextarea, isFalse);
+      };
 
-      final uiTextarea = readUiFor(
-        {
+      final uiSchema = {
+        'pwd': {
+          'ui:options': {'inputType': 'password'},
+        },
+      };
+
+      final form = FormGroup({
+        'pwd': FormControl<String>(),
+      });
+
+      final ctx = DjsfFieldContext(
+        type: 'password',
+        form: form,
+        schema: schema,
+        uiSchema: uiSchema,
+        path: 'pwd',
+        propSchema: (schema['properties']! as JsonMap)['pwd'] as JsonMap,
+        messages: IntlBundle(),
+      );
+
+      final ui = readUiFor(ctx);
+      expect(ui.isPassword, isTrue);
+      expect(ui.isTextarea, isFalse);
+    });
+
+    test('textarea flags', () {
+      final schema = <String, dynamic>{
+        'type': 'object',
+        'properties': <String, dynamic>{
           'bio': {
-            'ui:options': {'inputType': 'textarea'},
+            'type': 'string',
           },
         },
-        'bio',
+      };
+
+      final uiSchema = {
+        'bio': {
+          'ui:options': {'inputType': 'textarea'},
+        },
+      };
+
+      final form = FormGroup({
+        'bio': FormControl<String>(),
+      });
+
+      final ctx = DjsfFieldContext(
+        type: 'textarea',
+        form: form,
+        schema: schema,
+        uiSchema: uiSchema,
+        path: 'bio',
+        propSchema: (schema['properties']! as JsonMap)['bio'] as JsonMap,
+        messages: IntlBundle(),
       );
-      expect(uiTextarea.isTextarea, isTrue);
-      expect(uiTextarea.isPassword, isFalse);
+
+      final ui = readUiFor(ctx);
+
+      expect(ui.isTextarea, isTrue);
+      expect(ui.isPassword, isFalse);
       expect(
-        uiTextarea.keyboardTypeForString(),
+        ui.keyboardTypeForString(),
         isNull,
       ); // default for textarea
     });
 
     test('inputDecorationFromUi applies hint/help', () {
-      final ui = readUiFor(
-        {
+      final schema = <String, dynamic>{
+        'type': 'object',
+        'properties': <String, dynamic>{
           'name': {
-            'ui:placeholder': 'Full name',
-            'ui:help': 'At least 2 words',
+            'type': 'string',
           },
         },
-        'name',
+      };
+
+      final uiSchema = {
+        'name': {
+          'ui:placeholder': 'Full name',
+          'ui:help': 'At least 2 words',
+        },
+      };
+
+      final form = FormGroup({
+        'name': FormControl<String>(),
+      });
+
+      final ctx = DjsfFieldContext(
+        type: 'string',
+        form: form,
+        schema: schema,
+        uiSchema: uiSchema,
+        path: 'name',
+        propSchema: (schema['properties']! as JsonMap)['name'] as JsonMap,
+        messages: IntlBundle(),
       );
+
+      final ui = readUiFor(ctx);
 
       final dec = inputDecorationFromUi('Name', ui);
       expect(dec.labelText, equals('Name'));


### PR DESCRIPTION
Here’s a ready-to-paste PR package (title + rich description) that covers everything we added after the last PR:

---

### Overview

This PR delivers a major step toward RJSF parity and extensibility:

* **uiSchema support** for common field-level UX options.
* **Custom Field Registry** to plug in bespoke `ReactiveFormField`s.
* **Refactors & utilities** to standardize UI parsing and error messages.

---

### What’s Included

#### 1) uiSchema: first batch of props

Supported per-field attributes (RJSF-compatible):

* `ui:autofocus`
* `ui:emptyValue`
* `ui:placeholder`
* `ui:autocomplete` (mapped to `autofillHints`)
* `ui:description` (mapped to `helperText`)
* `ui:options.inputType` (`email`, `tel`, `url`, `number`, `password`, `textarea`, etc.)

#### 2) Field Registry & Custom Fields

* New **`DjsfFieldRegistry`** with **builder signature enforced** as `ReactiveFormField Function(...)` so all custom fields are reactive.
* Default builders for core types/widgets:

    * `string`, `integer`/`number`, `password`, `textarea`, `email`, `tel`.
* New base fields:

    * `DjsfTextField<T>`, `DjsfNumberField<T extends num>`, `DjsfTextAreaField`.
* Resolution order:

    1. `ui:widget` (if provided)
    2. `ui:options.inputType` (when applicable)
    3. JSON Schema `type`
    4. fallback to `string`

#### 3) Utilities & Refactors

* `readUiFor` → normalize `uiSchema` per field.
* `inputDecorationFromUi` → consistent label/hint/helper mapping.
* `messagesForField` → builds `Map<String, ValidationMessageFunction>` using i18n bundle + `transformErrors`.

#### 4) Examples (example app)

* **UiSchemaSimpleExample** — demonstrates the uiSchema attributes above.

#### 5) Tests

* **Core utils**: `readUiFor`, `inputDecorationFromUi`, `messagesForField` (with `transformErrors` override).
* **Fields**:

    * `DjsfTextField` — placeholder/helper/emptyValue handling.
    * `DjsfNumberField` — numeric keyboard + emptyValue coercion.
    * `DjsfTextAreaField` — multiline config + emptyValue.
* **FormRenderer registry resolution** — verifies selection by `ui:widget`, `ui:options.inputType`, and `type`.