### PR TITLE
feat: add array and nested object support with i18n labels and container registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# dart\_json\_schema\_form
+# dart\\_json\\_schema\\_form
 
 [![codecov](https://codecov.io/gh/reliance-engineer/dart_json_schema_form/graph/badge.svg?token=1MT24L1VK3)](https://codecov.io/gh/reliance-engineer/dart_json_schema_form)
 [![Made with Flutter](https://img.shields.io/badge/Made%20with-Flutter_%3E%3D_3.24.2-blue?logo=flutter)](https://flutter.dev)
@@ -16,12 +16,17 @@ It allows you to render dynamic forms in Flutter from a **JSON Schema** + **uiSc
 
 ### Features
 
-* Schema-based field rendering
-* Built-in validators from JSON Schema keywords
-* RJSF-style `transformErrors` for custom error messages
-* Built-in localized validation messages (`en`, `es`, `de`, `it`, `pt`, `fr`, `nl`, `ja`, `zh`, `ru`, `pl`)
-* `uiSchema` props (`ui:placeholder`, `ui:description`, `ui:options.inputType`, etc.)
-* Custom field registry for extensibility
+  * Schema-based field rendering
+  * Built-in validators from JSON Schema keywords
+  * RJSF-style `transformErrors` for custom error messages
+  * Built-in localized validation messages (`en`, `es`, `de`, `it`, `pt`, `fr`, `nl`, `ja`, `zh`, `ru`, `pl`)
+  * `uiSchema` props (`ui:placeholder`, `ui:description`, `ui:options.inputType`, etc.)
+  * Custom field registry for extensibility
+  * Arrays with `minItems`, `maxItems`, `uniqueItems`
+  * Nested objects rendered as sub-forms
+  * Localized UI labels for arrays (`arrayAddItem`, `arrayRemoveItem`, `arrayItemTitle`)
+  * Container registry to override array rendering
+
 
 ---
 
@@ -33,8 +38,9 @@ It allows you to render dynamic forms in Flutter from a **JSON Schema** + **uiSc
 4. [Custom Validation Messages (transformErrors)](#custom-validation-messages-transformerrors)
 5. [Built-in Validation Messages (i18n)](#built-in-validation-messages-i18n)
 6. [uiSchema Example](#uischema-example)
-7. [Custom Fields](#️-custom-fields)
-8. [Docs & Contributing](#-docs--contributing)
+7. [Custom Fields](#custom-fields)
+8. [Arrays and Objects](#arrays-and-objects)
+9. [Docs & Contributing](#docs--contributing)
 
 ---
 
@@ -262,6 +268,132 @@ Resolution order:
 4. fallback to `string`
 
 ---
+
+✅ With these options, you can render dynamic forms with validators, customize or translate messages, and integrate seamlessly into your Flutter app.
+
+## 📜 Arrays and Objects
+
+### 📦 Arrays Example
+
+```dart
+final schema = {
+  "title": "Tags",
+  "type": "object",
+  "properties": {
+    "tags": {
+      "type": "array",
+      "title": "Tags",
+      "items": {"type": "string", "title": "Tag"},
+      "minItems": 1
+    }
+  }
+};
+
+final uiSchema = {
+  "tags": {
+    "ui:options": {
+      "addButtonText": "Add tag",
+      "removable": true
+    }
+  }
+};
+
+DjsfForm(schema: schema, uiSchema: uiSchema);
+```
+
+Supported array options:
+
+* `minItems`, `maxItems`, `uniqueItems`
+* `ui:options.addButtonText` (button label)
+* `ui:options.addable`, `removable`, `orderable`
+
+---
+
+### 🏗️ Nested Objects Example
+
+```dart
+final schema = {
+  "title": "User",
+  "type": "object",
+  "properties": {
+    "addresses": {
+      "type": "array",
+      "title": "Addresses",
+      "items": {
+        "type": "object",
+        "title": "Address",
+        "required": ["city"],
+        "properties": {
+          "street": {"type": "string", "title": "Street"},
+          "city": {"type": "string", "title": "City"},
+          "zip": {"type": "string", "title": "ZIP", "pattern": r"^[0-9]{5}$"}
+        }
+      },
+      "minItems": 1
+    }
+  }
+};
+
+final uiSchema = {
+  "addresses": {
+    "ui:options": {"addButtonText": "Add address"},
+    "items": {
+      "street": {"ui:placeholder": "Main St 123"},
+      "zip": {"ui:placeholder": "12345"}
+    }
+  }
+};
+
+DjsfForm(schema: schema, uiSchema: uiSchema);
+```
+
+✅ This renders a list of nested forms where each item is a full address object.
+
+---
+
+### 🌐 Localized UI Labels
+
+Array-related labels (`Add item`, `Remove`, `Item #n`) are localized through the same Intl ARB files as validation messages.
+
+Default ARB keys:
+
+```jsonc
+"arrayAddItem": "Add item",
+"arrayRemoveItem": "Remove",
+"arrayItemTitle": "Item {index}"
+```
+
+Example in Spanish (`intl_es.arb`):
+
+```jsonc
+"arrayAddItem": "Añadir elemento",
+"arrayRemoveItem": "Eliminar",
+"arrayItemTitle": "Elemento {index}"
+```
+
+Usage (auto-resolves by locale):
+
+```dart
+DjsfForm(schema: schema, locale: \'es\');
+```
+
+---
+
+### 🔌 Container Registry (advanced)
+
+Developers can override how arrays are rendered via the container registry:
+
+```dart
+final myContainers = defaultContainerRegistry().copyWith(
+  arrayBuilder: (ctx) => MyFancyArrayWidget(ctx: ctx),
+);
+
+DjsfForm(
+  schema: schema,
+  uiSchema: uiSchema,
+  containerRegistry: myContainers,
+);
+```
 
 ## 📚 Docs & Contributing
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,9 @@ Resolution order:
 ## 📜 Arrays and Objects
 
 ### 📦 Arrays Example
+--
+#### Dynamic Array
+This json will render a --"dynamic"-- array of fields. New fields can be added and/or removed from the form. Each item will have a field with the specified `item.type`.
 
 ```dart
 final schema = {
@@ -308,9 +311,37 @@ DjsfForm(schema: schema, uiSchema: uiSchema);
 
 Supported array options:
 
-* `minItems`, `maxItems`, `uniqueItems`
-* `ui:options.addButtonText` (button label)
-* `ui:options.addable`, `removable`, `orderable`
+* `minItems` : If defined the form will start with an empty blanc field. If not then just the `Add Item` button will be shown.
+* `maxItems`, `uniqueItems` : Used for validation.
+* `ui:options.addButtonText`: To modify the `Add Item` label.
+* `ui:options.addable`, `removable`, `orderable`: If you want the list to be static, removable or orderable.
+
+--
+
+#### Static Array
+
+This json will render a --"static"-- array of fields. Is not possible to add new fields to the array. Each item will have a field with the specified `item.type`.
+
+```dart
+final schema = {
+  "title": "Tags",
+  "type": "object",
+  "properties": {
+    "tags": {
+      "type": "array",
+      "title": "Tags",
+      "items": [
+         {"type": "string", "title": "Tag"}
+       ],
+    }
+  }
+};
+
+final uiSchema = {
+};
+
+DjsfForm(schema: schema, uiSchema: uiSchema);
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,15 +32,20 @@ It allows you to render dynamic forms in Flutter from a **JSON Schema** + **uiSc
 
 ## 📑 Table of Contents
 
-1. [Installation](#installation)
-2. [Basic Usage](#basic-usage)
-3. [Validation Example](#validation-example)
-4. [Custom Validation Messages (transformErrors)](#custom-validation-messages-transformerrors)
-5. [Built-in Validation Messages (i18n)](#built-in-validation-messages-i18n)
-6. [uiSchema Example](#uischema-example)
-7. [Custom Fields](#custom-fields)
-8. [Arrays and Objects](#arrays-and-objects)
-9. [Docs & Contributing](#docs--contributing)
+- [Overview](#-overview)
+- [Basic Usage](#-basic-usage)
+- [Validation Example](#-validation-example)
+- [Custom Validation Messages (transformErrors)](#-custom-validation-messages-transformerrors)
+- [Built-in Validation Messages (i18n)](#-built-in-validation-messages-i18n))
+- [uiSchema Example](#-uischema-example)
+- [Custom Fields](#%EF%B8%8F-custom-fields)
+- [Arrays and Objects](#-arrays-and-objects)
+   * [Arrays Example](#-arrays-example)
+   * [Nested Objects Example](#%EF%B8%8F-nested-objects-example)
+   * [Localized UI Labels](#-localized-ui-labels)
+   * [Container Registry (advanced)](#-container-registry-advanced)
+- [Docs & Contributing](#-docs--contributing)
+
 
 ---
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -6,7 +6,7 @@ linter:
   rules:
     require_trailing_commas: true
     always_use_package_imports: true
-    avoid_dynamic_calls: true
+    avoid_dynamic_calls: false
     avoid_empty_else: true
     avoid_print: true
     avoid_types_as_parameter_names: true

--- a/example/lib/examples/array_simple_example.dart
+++ b/example/lib/examples/array_simple_example.dart
@@ -8,11 +8,19 @@ final _schema = {
     "tags": {
       "type": "array",
       "title": "Tags",
-      "items": {"type": "string", "title": "Tag"},
+      "items": {
+        "type": "object",
+        "title": "Tag",
+        "properties": {
+          "name": {"type": "string", "title": "Name", "default": "foo"},
+          "age": {"type": "integer", "title": "Age", "default": "10"},
+        },
+      },
       "minItems": 1,
     },
   },
 };
+
 final _uiSchema = {
   "tags": {
     "ui:options": {"addButtonText": "Add tag", "removable": true},
@@ -46,6 +54,12 @@ class ArraySimpleExample extends StatefulWidget {
 
 class _ArraySimpleExampleState extends State<ArraySimpleExample> {
   String language = 'en';
+  JsonMap? formData;
+
+  @override
+  void initState() {
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -82,6 +96,8 @@ class _ArraySimpleExampleState extends State<ArraySimpleExample> {
                 child: DjsfForm(
                   schema: _schema,
                   uiSchema: _uiSchema,
+                  formData: formData,
+                  onChanged: (data) => setState(() => formData = data),
                   locale: language,
                 ),
               ),

--- a/example/lib/examples/array_simple_example.dart
+++ b/example/lib/examples/array_simple_example.dart
@@ -2,17 +2,20 @@ import 'package:dart_json_schema_form/dart_json_schema_form.dart';
 import 'package:flutter/material.dart';
 
 final _schema = {
-  "title": "Sign up",
-  "required": ["email"],
+  "title": "Tags",
+  "type": "object",
   "properties": {
-    "firstName": {"type": "string", "title": "Full Name", "minLength": 5},
-    "lastName": {"type": "string", "title": "Last Name", "minLength": 5},
-    "email": {
-      "type": "string",
-      "title": "Email",
-      "pattern": r"^[^\s@]+@[^\s@]+\.[^\s@]+$",
+    "tags": {
+      "type": "array",
+      "title": "Tags",
+      "items": {"type": "string", "title": "Tag"},
+      "minItems": 1,
     },
-    "age": {"type": "integer", "title": "Age", "minimum": 18},
+  },
+};
+final _uiSchema = {
+  "tags": {
+    "ui:options": {"addButtonText": "Add tag", "removable": true},
   },
 };
 
@@ -30,24 +33,24 @@ const languages = [
   'pl',
 ];
 
-class L18nMessagesExample extends StatefulWidget {
-  static const route = '/l18n';
-  static const title = 'Internationalization Example';
-  static const description = 'Show validation messages in built-in languages';
+class ArraySimpleExample extends StatefulWidget {
+  const ArraySimpleExample({super.key});
 
-  const L18nMessagesExample({super.key});
+  static const route = '/array-simple';
+  static const title = 'Array simple Example';
+  static const description = 'Simple example with Array field';
 
   @override
-  State<L18nMessagesExample> createState() => _L18nMessagesExampleState();
+  State<ArraySimpleExample> createState() => _ArraySimpleExampleState();
 }
 
-class _L18nMessagesExampleState extends State<L18nMessagesExample> {
+class _ArraySimpleExampleState extends State<ArraySimpleExample> {
   String language = 'en';
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text(L18nMessagesExample.title)),
+      appBar: AppBar(title: const Text(ArraySimpleExample.title)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: SingleChildScrollView(
@@ -75,7 +78,13 @@ class _L18nMessagesExampleState extends State<L18nMessagesExample> {
                 ),
               ),
               Divider(height: 12),
-              Flexible(child: DjsfForm(schema: _schema, locale: language)),
+              Flexible(
+                child: DjsfForm(
+                  schema: _schema,
+                  uiSchema: _uiSchema,
+                  locale: language,
+                ),
+              ),
             ],
           ),
         ),

--- a/example/lib/examples/l18n_custom_bundle_example.dart
+++ b/example/lib/examples/l18n_custom_bundle_example.dart
@@ -71,7 +71,9 @@ class MyCustomBundle extends DjsfMessageBundle {
 }
 
 class L18nCustomBundlesExample extends StatefulWidget {
-  static const route = '/custom_l18n';
+  static const route = '/custom_l10n';
+  static const title = 'Custom I18n Example';
+  static const description = 'Show custom translations for validation messages';
 
   const L18nCustomBundlesExample({super.key});
 
@@ -86,9 +88,7 @@ class _L18nCustomBundlesExampleState extends State<L18nCustomBundlesExample> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('DJSF Custom Internationalization Example'),
-      ),
+      appBar: AppBar(title: const Text(L18nCustomBundlesExample.title)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: SingleChildScrollView(

--- a/example/lib/examples/ui_schema_simple_example.dart
+++ b/example/lib/examples/ui_schema_simple_example.dart
@@ -51,6 +51,8 @@ const languages = [
 
 class UiSchemaSimpleExample extends StatefulWidget {
   static const route = '/simple-ui-example';
+  static const title = 'UI Schema simple Example';
+  static const description = 'Simple example applying uiSchema';
 
   const UiSchemaSimpleExample({super.key});
 
@@ -64,7 +66,7 @@ class _UiSchemaSimpleExampleState extends State<UiSchemaSimpleExample> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('DJSF UI Schema Simple Example')),
+      appBar: AppBar(title: const Text(UiSchemaSimpleExample.title)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: SingleChildScrollView(

--- a/example/lib/examples/validation_messages_example.dart
+++ b/example/lib/examples/validation_messages_example.dart
@@ -17,13 +17,15 @@ final validationMessagesSchema = {
 
 class ValidationMessagesExample extends StatelessWidget {
   static const route = '/validation';
+  static const title = 'Validation messages';
+  static const description = 'Form validation with custom messages';
 
   const ValidationMessagesExample({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('DJSF Validation messages')),
+      appBar: AppBar(title: const Text(title)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: DjsfForm(

--- a/example/lib/examples/very_simple_form_example.dart
+++ b/example/lib/examples/very_simple_form_example.dart
@@ -17,11 +17,13 @@ class VerySimpleFormExample extends StatelessWidget {
   const VerySimpleFormExample({super.key});
 
   static const route = '/very-simple';
+  static const title = 'Very simple form';
+  static const description = 'Minimal example with title & description';
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('DJSF Very Simple Example')),
+      appBar: AppBar(title: const Text(VerySimpleFormExample.title)),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: DjsfForm(schema: _schema, uiSchema: _uiSchema),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:dart_json_schema_form/generated/l10n.dart' as djsf_l10n;
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
+
+import 'examples/array_simple_example.dart';
 import 'examples/l18n_custom_bundle_example.dart';
 import 'examples/l18n_messages_example.dart';
 import 'examples/ui_schema_simple_example.dart';
@@ -10,6 +12,39 @@ import 'examples/very_simple_form_example.dart';
 void main() {
   runApp(const MyApp());
 }
+
+final examples = <Map<String, String>>[
+  {
+    "title": VerySimpleFormExample.title,
+    "description": VerySimpleFormExample.description,
+    "route": VerySimpleFormExample.route,
+  },
+  {
+    "title": ValidationMessagesExample.title,
+    "description": ValidationMessagesExample.description,
+    "route": ValidationMessagesExample.route,
+  },
+  {
+    "title": L18nMessagesExample.title,
+    "description": L18nMessagesExample.description,
+    "route": L18nMessagesExample.route,
+  },
+  {
+    "title": L18nCustomBundlesExample.title,
+    "description": L18nCustomBundlesExample.description,
+    "route": L18nCustomBundlesExample.route,
+  },
+  {
+    "title": UiSchemaSimpleExample.title,
+    "description": UiSchemaSimpleExample.description,
+    "route": UiSchemaSimpleExample.route,
+  },
+  {
+    "title": ArraySimpleExample.title,
+    "description": ArraySimpleExample.description,
+    "route": ArraySimpleExample.route,
+  },
+];
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -35,6 +70,7 @@ class MyApp extends StatelessWidget {
         L18nMessagesExample.route: (_) => const L18nMessagesExample(),
         L18nCustomBundlesExample.route: (_) => const L18nCustomBundlesExample(),
         UiSchemaSimpleExample.route: (_) => const UiSchemaSimpleExample(),
+        ArraySimpleExample.route: (_) => const ArraySimpleExample(),
       },
     );
   }
@@ -42,71 +78,28 @@ class MyApp extends StatelessWidget {
 
 class _HomePage extends StatelessWidget {
   const _HomePage({required this.title});
+
   final String title;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: Text(title)),
-      body: ListView(
+      body: ListView.separated(
         padding: const EdgeInsets.all(12),
-        children: [
-          // Botón de navegación a tu ejemplo
-          ListTile(
-            title: const Text('Very simple form'),
-            subtitle: const Text('Minimal example with title & description'),
+        itemCount: examples.length,
+        itemBuilder: (_, index) {
+          final item = examples[index];
+          return ListTile(
+            title: Text(item['title']!),
+            subtitle: Text(item['description']!),
             trailing: const Icon(Icons.chevron_right),
-            onTap:
-                () => Navigator.of(
-                  context,
-                ).pushNamed(VerySimpleFormExample.route),
-          ),
-          const Divider(),
-          ListTile(
-            title: const Text('Validation messages'),
-            subtitle: const Text('Form validation with custom messages'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap:
-                () => Navigator.of(
-                  context,
-                ).pushNamed(ValidationMessagesExample.route),
-          ),
-          const Divider(),
-          ListTile(
-            title: const Text('Internationalization Example'),
-            subtitle: const Text(
-              'Show validation messages in built-in languages',
-            ),
-            trailing: const Icon(Icons.chevron_right),
-            onTap:
-                () =>
-                    Navigator.of(context).pushNamed(L18nMessagesExample.route),
-          ),
-          const Divider(),
-          ListTile(
-            title: const Text('Custom Internationalization Example'),
-            subtitle: const Text(
-              'Show custom translations for validation messages',
-            ),
-            trailing: const Icon(Icons.chevron_right),
-            onTap:
-                () => Navigator.of(
-                  context,
-                ).pushNamed(L18nCustomBundlesExample.route),
-          ),
-          const Divider(),
-          ListTile(
-            title: const Text('UI Schema simple Example'),
-            subtitle: const Text('Simple example applying uiSchema'),
-            trailing: const Icon(Icons.chevron_right),
-            onTap:
-                () => Navigator.of(
-                  context,
-                ).pushNamed(UiSchemaSimpleExample.route),
-          ),
-          const Divider(),
-          // Here will come more examples.
-        ],
+            onTap: () => Navigator.of(context).pushNamed(item['route']!),
+          );
+        },
+        separatorBuilder: (_, __) => const Divider(),
+        addAutomaticKeepAlives: false,
+        addRepaintBoundaries: false,
       ),
     );
   }

--- a/example/test/main_test.dart
+++ b/example/test/main_test.dart
@@ -1,5 +1,9 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:example/examples/l18n_custom_bundle_example.dart';
+import 'package:example/examples/l18n_messages_example.dart';
+import 'package:example/examples/validation_messages_example.dart';
+import 'package:example/examples/very_simple_form_example.dart';
 import 'package:example/main.dart'; // Ajusta si tu package del example tiene otro name en pubspec
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('Home shows list and navigates to VerySimpleFormExample', (
@@ -11,14 +15,14 @@ void main() {
 
     // Home visible
     expect(find.text('DJSF Examples'), findsOneWidget);
-    expect(find.text('Very simple form'), findsOneWidget);
+    expect(find.text(VerySimpleFormExample.title), findsOneWidget);
 
     // Tap en el item
-    await tester.tap(find.text('Very simple form'));
+    await tester.tap(find.text(VerySimpleFormExample.title));
     await tester.pumpAndSettle();
 
     // Llegamos a la pantalla del ejemplo
-    expect(find.text('DJSF Very Simple Example'), findsOneWidget);
+    expect(find.text(VerySimpleFormExample.title), findsOneWidget);
 
     // Volver atrás
     await tester.pageBack();
@@ -37,14 +41,14 @@ void main() {
 
     // Home visible
     expect(find.text('DJSF Examples'), findsOneWidget);
-    expect(find.text('Validation messages'), findsOneWidget);
+    expect(find.text(ValidationMessagesExample.title), findsOneWidget);
 
     // Tap en el item
-    await tester.tap(find.text('Validation messages'));
+    await tester.tap(find.text(ValidationMessagesExample.title));
     await tester.pumpAndSettle();
 
     // Llegamos a la pantalla del ejemplo
-    expect(find.text('DJSF Validation messages'), findsOneWidget);
+    expect(find.text(ValidationMessagesExample.title), findsOneWidget);
 
     // Volver atrás
     await tester.pageBack();
@@ -63,14 +67,14 @@ void main() {
 
     // Home visible
     expect(find.text('DJSF Examples'), findsOneWidget);
-    expect(find.text('Internationalization Example'), findsOneWidget);
+    expect(find.text(L18nMessagesExample.title), findsOneWidget);
 
     // Tap en el item
-    await tester.tap(find.text('Internationalization Example'));
+    await tester.tap(find.text(L18nMessagesExample.title));
     await tester.pumpAndSettle();
 
     // Llegamos a la pantalla del ejemplo
-    expect(find.text('DJSF Internationalization Example'), findsOneWidget);
+    expect(find.text(L18nMessagesExample.title), findsOneWidget);
 
     // Volver atrás
     await tester.pageBack();
@@ -89,17 +93,14 @@ void main() {
 
     // Home visible
     expect(find.text('DJSF Examples'), findsOneWidget);
-    expect(find.text('Custom Internationalization Example'), findsOneWidget);
+    expect(find.text(L18nCustomBundlesExample.title), findsOneWidget);
 
     // Tap en el item
-    await tester.tap(find.text('Custom Internationalization Example'));
+    await tester.tap(find.text(L18nCustomBundlesExample.title));
     await tester.pumpAndSettle();
 
     // Llegamos a la pantalla del ejemplo
-    expect(
-      find.text('DJSF Custom Internationalization Example'),
-      findsOneWidget,
-    );
+    expect(find.text(L18nCustomBundlesExample.title), findsOneWidget);
 
     // Volver atrás
     await tester.pageBack();

--- a/example/test/test/array_simple_example_test.dart
+++ b/example/test/test/array_simple_example_test.dart
@@ -1,0 +1,69 @@
+import 'package:example/examples/array_simple_example.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+
+import '../utils/base_app.dart';
+
+void main() {
+  group('ArraySimpleExample Tests', () {
+    testWidgets('Renders initial UI correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(const BaseApp(child: ArraySimpleExample()));
+
+      await tester.pumpAndSettle();
+
+      // Verify AppBar title
+      expect(find.text(ArraySimpleExample.title), findsOneWidget);
+
+      // Verify language selection buttons are present
+      for (final lang in languages) {
+        expect(find.text(lang.toUpperCase()), findsOneWidget);
+      }
+
+      // Verify DjsfForm is present
+      expect(find.byType(DjsfForm), findsOneWidget);
+
+      // Verify "Add tag" button (text might be inside the DjsfForm's default add button)
+      // DjsfForm uses "Add" by default for array items if addButtonText is not customized in uiSchema for items
+      // The uiSchema provided customizes "addButtonText": "Add tag" for the "tags" array itself.
+      expect(find.text('Add tag'), findsOneWidget);
+
+      // Initially, because of minItems: 1, one item should be present.
+      // The default item title for a string array item is "Item" unless specified.
+      // The schema specifies "title": "Tag" for items.
+      expect(find.text('Tag'), findsOneWidget);
+    });
+
+    testWidgets('Can add and remove tags', (WidgetTester tester) async {
+      await tester.pumpWidget(const BaseApp(child: ArraySimpleExample()));
+
+      await tester.pumpAndSettle();
+
+      // Initial state should have one tag input due to minItems: 1
+      expect(find.text('Tag'), findsOneWidget);
+
+      // Type Tag 2 and Tap "Add tag" button
+      await tester.tap(find.text('Add tag'));
+      await tester.pumpAndSettle(); // Allow UI to update
+
+      // Now there should be two tag input fields
+      expect(find.text('Tag'), findsNWidgets(2));
+
+      // Find the "Remove" button for the second tag.
+      // Assuming the remove button is an Icon button with Icons.delete
+      // and it's associated with the second item.
+      // The uiSchema has "removable": true
+      final removeButtons = find.text('Remove');
+      expect(
+        removeButtons,
+        findsNWidgets(2),
+      ); // One for each item, as minItems is 1 and removable is true
+
+      // Tap the "Remove" button for the second tag
+      await tester.tap(removeButtons.last);
+      await tester.pumpAndSettle();
+
+      // Now there should be only one tag input field left
+      expect(find.text('Tag'), findsOneWidget);
+    });
+  });
+}

--- a/example/test/test/i18n_custom_bundle_example_test.dart
+++ b/example/test/test/i18n_custom_bundle_example_test.dart
@@ -14,10 +14,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // App bar
-        expect(
-          find.text('DJSF Custom Internationalization Example'),
-          findsOneWidget,
-        );
+        expect(find.text(L18nCustomBundlesExample.title), findsOneWidget);
 
         // Language buttons exist
         for (final code in languages) {

--- a/example/test/test/i18n_custom_bundle_example_test.dart
+++ b/example/test/test/i18n_custom_bundle_example_test.dart
@@ -1,6 +1,7 @@
 import 'package:example/examples/l18n_custom_bundle_example.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../utils/base_app.dart';
 
 void main() {
   group('L18nMessagesExample', () {
@@ -8,7 +9,7 @@ void main() {
       'renders and switches required message between EN and ES shows custom message',
       (tester) async {
         await tester.pumpWidget(
-          const MaterialApp(home: L18nCustomBundlesExample()),
+          const BaseApp(child: L18nCustomBundlesExample()),
         );
 
         await tester.pumpAndSettle();

--- a/example/test/test/i18n_messages_example_test.dart
+++ b/example/test/test/i18n_messages_example_test.dart
@@ -12,7 +12,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // App bar
-      expect(find.text('DJSF Internationalization Example'), findsOneWidget);
+      expect(find.text(L18nMessagesExample.title), findsOneWidget);
 
       // Language buttons exist
       for (final code in languages) {

--- a/example/test/test/i18n_messages_example_test.dart
+++ b/example/test/test/i18n_messages_example_test.dart
@@ -1,13 +1,14 @@
 import 'package:example/examples/l18n_messages_example.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+import '../utils/base_app.dart';
 
 void main() {
   group('L18nMessagesExample', () {
     testWidgets('renders and switches required message between EN and ES', (
       tester,
     ) async {
-      await tester.pumpWidget(const MaterialApp(home: L18nMessagesExample()));
+      await tester.pumpWidget(const BaseApp(child: L18nMessagesExample()));
 
       await tester.pumpAndSettle();
 
@@ -38,7 +39,7 @@ void main() {
     testWidgets('switches to DE and shows the German required message', (
       tester,
     ) async {
-      await tester.pumpWidget(const MaterialApp(home: L18nMessagesExample()));
+      await tester.pumpWidget(const BaseApp(child: L18nMessagesExample()));
 
       // Switch to DE
       await tester.tap(find.text('DE'));

--- a/example/test/test/validation_messages_example_test.dart
+++ b/example/test/test/validation_messages_example_test.dart
@@ -2,13 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:example/examples/validation_messages_example.dart';
 
+import '../utils/base_app.dart';
+
 void main() {
   group('ValidationMessagesExample', () {
     testWidgets(
       'renders and shows default + custom messages via transformErrors',
       (tester) async {
         await tester.pumpWidget(
-          const MaterialApp(home: ValidationMessagesExample()),
+          const BaseApp(child: ValidationMessagesExample()),
         );
 
         await tester.pumpAndSettle();

--- a/example/test/test/validation_messages_example_test.dart
+++ b/example/test/test/validation_messages_example_test.dart
@@ -14,7 +14,7 @@ void main() {
         await tester.pumpAndSettle();
 
         // App bar
-        expect(find.text('DJSF Validation messages'), findsOneWidget);
+        expect(find.text(ValidationMessagesExample.title), findsOneWidget);
 
         // Field labels
         expect(find.text('Full Name'), findsOneWidget);

--- a/example/test/test/very_simple_form_example_test.dart
+++ b/example/test/test/very_simple_form_example_test.dart
@@ -12,7 +12,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // App bar title
-      expect(find.text('DJSF Very Simple Example'), findsOneWidget);
+      expect(find.text(VerySimpleFormExample.title), findsOneWidget);
 
       // Schema title & description
       expect(find.text('A registration form'), findsOneWidget);

--- a/example/test/test/very_simple_form_example_test.dart
+++ b/example/test/test/very_simple_form_example_test.dart
@@ -1,13 +1,14 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 import 'package:example/examples/very_simple_form_example.dart';
+
+import '../utils/base_app.dart';
 
 void main() {
   testWidgets(
     'VerySimpleFormExample renders title, description, and the form field',
     (tester) async {
-      await tester.pumpWidget(const MaterialApp(home: VerySimpleFormExample()));
+      await tester.pumpWidget(const BaseApp(child: VerySimpleFormExample()));
 
       await tester.pumpAndSettle();
 

--- a/example/test/utils/base_app.dart
+++ b/example/test/utils/base_app.dart
@@ -1,0 +1,22 @@
+import 'package:dart_json_schema_form/generated/l10n.dart' as djsf_l10n;
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+class BaseApp extends StatelessWidget {
+  final Widget child;
+
+  const BaseApp({required this.child, super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      localizationsDelegates: const [
+        djsf_l10n.S.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      home: child,
+    );
+  }
+}

--- a/lib/dart_json_schema_form.dart
+++ b/lib/dart_json_schema_form.dart
@@ -1,3 +1,4 @@
 export 'src/djsf_form.dart';
 export 'src/types/types.dart';
+export 'src/types/i18n.dart';
 export 'src/fields/fields.dart';

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -11,5 +11,13 @@
   "max": "Muss ≤ {limit} sein",
   "@max": {"placeholders": {"limit": {}}},
   "equals": "Muss {allowed} entsprechen",
-  "@equals": {"placeholders": {"allowed": {}}}
+  "@equals": {"placeholders": {"allowed": {}}},
+  "arrayAddItem": "Element hinzufügen",
+  "arrayRemoveItem": "Entfernen",
+  "arrayItemTitle": "Element {index}",
+  "@arrayItemTitle": {
+    "placeholders": {
+      "index": { "type": "int" }
+    }
+  }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -11,5 +11,13 @@
   "max": "Must be ≤ {limit}",
   "@max": {"placeholders": {"limit": {}}},
   "equals": "Must equal {allowed}",
-  "@equals": {"placeholders": {"allowed": {}}}
+  "@equals": {"placeholders": {"allowed": {}}},
+  "arrayAddItem": "Add item",
+  "arrayRemoveItem": "Remove",
+  "arrayItemTitle": "Item {index}",
+  "@arrayItemTitle": {
+    "placeholders": {
+      "index": { "type": "int" }
+    }
+  }
 }

--- a/lib/l10n/intl_es.arb
+++ b/lib/l10n/intl_es.arb
@@ -11,5 +11,13 @@
   "max": "Debe ser ≤ {limit}",
   "@max": {"placeholders": {"limit": {}}},
   "equals": "Debe ser igual a {allowed}",
-  "@equals": {"placeholders": {"allowed": {}}}
+  "@equals": {"placeholders": {"allowed": {}}},
+  "arrayAddItem": "Añadir elemento",
+  "arrayRemoveItem": "Eliminar",
+  "arrayItemTitle": "Elemento {index}",
+  "@arrayItemTitle": {
+    "placeholders": {
+      "index": { "type": "int" }
+    }
+  }
 }

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -11,5 +11,13 @@
   "max": "Doit être ≤ {limit}",
   "@max": {"placeholders": {"limit": {}}},
   "equals": "Doit être égal à {allowed}",
-  "@equals": {"placeholders": {"allowed": {}}}
+  "@equals": {"placeholders": {"allowed": {}}},
+  "arrayAddItem": "Ajouter un élément",
+  "arrayRemoveItem": "Supprimer",
+  "arrayItemTitle": "Élément {index}",
+  "@arrayItemTitle": {
+    "placeholders": {
+      "index": { "type": "int" }
+    }
+  }
 }

--- a/lib/l10n/intl_it.arb
+++ b/lib/l10n/intl_it.arb
@@ -11,5 +11,13 @@
   "max": "Deve essere ≤ {limit}",
   "@max": {"placeholders": {"limit": {}}},
   "equals": "Deve essere uguale a {allowed}",
-  "@equals": {"placeholders": {"allowed": {}}}
+  "@equals": {"placeholders": {"allowed": {}}},
+  "arrayAddItem": "Aggiungi elemento",
+  "arrayRemoveItem": "Rimuovi",
+  "arrayItemTitle": "Elemento {index}",
+  "@arrayItemTitle": {
+    "placeholders": {
+      "index": { "type": "int" }
+    }
+  }
 }

--- a/lib/l10n/intl_ja.arb
+++ b/lib/l10n/intl_ja.arb
@@ -11,5 +11,13 @@
   "max": "{limit}以下である必要があります",
   "@max": {"placeholders": {"limit": {}}},
   "equals": "{allowed}と等しくなければなりません",
-  "@equals": {"placeholders": {"allowed": {}}}
+  "@equals": {"placeholders": {"allowed": {}}},
+  "arrayAddItem": "項目を追加",
+  "arrayRemoveItem": "削除",
+  "arrayItemTitle": "項目 {index}",
+  "@arrayItemTitle": {
+    "placeholders": {
+      "index": { "type": "int" }
+    }
+  }
 }

--- a/lib/l10n/intl_nl.arb
+++ b/lib/l10n/intl_nl.arb
@@ -11,5 +11,13 @@
   "max": "Moet ≤ {limit} zijn",
   "@max": {"placeholders": {"limit": {}}},
   "equals": "Moet gelijk zijn aan {allowed}",
-  "@equals": {"placeholders": {"allowed": {}}}
+  "@equals": {"placeholders": {"allowed": {}}},
+  "arrayAddItem": "Item toevoegen",
+  "arrayRemoveItem": "Verwijderen",
+  "arrayItemTitle": "Item {index}",
+  "@arrayItemTitle": {
+    "placeholders": {
+      "index": { "type": "int" }
+    }
+  }
 }

--- a/lib/l10n/intl_pl.arb
+++ b/lib/l10n/intl_pl.arb
@@ -11,5 +11,13 @@
   "max": "Musi być ≤ {limit}",
   "@max": {"placeholders": {"limit": {}}},
   "equals": "Musi być równe {allowed}",
-  "@equals": {"placeholders": {"allowed": {}}}
+  "@equals": {"placeholders": {"allowed": {}}},
+  "arrayAddItem": "Dodaj element",
+  "arrayRemoveItem": "Usuń",
+  "arrayItemTitle": "Element {index}",
+  "@arrayItemTitle": {
+    "placeholders": {
+      "index": { "type": "int" }
+    }
+  }
 }

--- a/lib/l10n/intl_pt.arb
+++ b/lib/l10n/intl_pt.arb
@@ -11,5 +11,13 @@
   "max": "Deve ser ≤ {limit}",
   "@max": {"placeholders": {"limit": {}}},
   "equals": "Deve ser igual a {allowed}",
-  "@equals": {"placeholders": {"allowed": {}}}
+  "@equals": {"placeholders": {"allowed": {}}},
+  "arrayAddItem": "Adicionar item",
+  "arrayRemoveItem": "Remover",
+  "arrayItemTitle": "Item {index}",
+  "@arrayItemTitle": {
+    "placeholders": {
+      "index": { "type": "int" }
+    }
+  }
 }

--- a/lib/l10n/intl_ru.arb
+++ b/lib/l10n/intl_ru.arb
@@ -11,5 +11,13 @@
   "max": "Значение должно быть ≤ {limit}",
   "@max": {"placeholders": {"limit": {}}},
   "equals": "Значение должно быть равно {allowed}",
-  "@equals": {"placeholders": {"allowed": {}}}
+  "@equals": {"placeholders": {"allowed": {}}},
+  "arrayAddItem": "Добавить элемент",
+  "arrayRemoveItem": "Удалить",
+  "arrayItemTitle": "Элемент {index}",
+  "@arrayItemTitle": {
+    "placeholders": {
+      "index": { "type": "int" }
+    }
+  }
 }

--- a/lib/l10n/intl_zh.arb
+++ b/lib/l10n/intl_zh.arb
@@ -11,5 +11,13 @@
   "max": "必须 ≤ {limit}",
   "@max": {"placeholders": {"limit": {}}},
   "equals": "必须等于 {allowed}",
-  "@equals": {"placeholders": {"allowed": {}}}
+  "@equals": {"placeholders": {"allowed": {}}},
+  "arrayAddItem": "項目を追加",
+  "arrayRemoveItem": "削除",
+  "arrayItemTitle": "項目 {index}",
+  "@arrayItemTitle": {
+    "placeholders": {
+      "index": { "type": "int" }
+    }
+  }
 }

--- a/lib/src/containers/containers.dart
+++ b/lib/src/containers/containers.dart
@@ -1,0 +1,3 @@
+export 'registry.dart';
+export 'context.dart';
+export 'defaults.dart';

--- a/lib/src/containers/context.dart
+++ b/lib/src/containers/context.dart
@@ -1,0 +1,26 @@
+// lib/src/fields/context.dart
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+class DjsfArrayContext {
+  DjsfArrayContext({
+    required this.control,
+    required this.arraySchema,
+    required this.arrayUiSchema,
+    required this.messages,
+    required this.transformErrors,
+    required this.fieldRegistry,
+    required this.fieldName,
+    required this.parentSchema,
+  });
+
+  final FormArray control;
+  final JsonMap arraySchema;
+  final JsonMap arrayUiSchema;
+  final DjsfMessageBundle messages;
+  final TransformErrors? transformErrors;
+  final DjsfFieldRegistry fieldRegistry;
+
+  final String fieldName;
+  final JsonMap parentSchema;
+}

--- a/lib/src/containers/defaults.dart
+++ b/lib/src/containers/defaults.dart
@@ -3,13 +3,9 @@ import 'package:dart_json_schema_form/src/containers/defaults/array_field.dart';
 
 DjsfContainerRegistry defaultContainerRegistry() => DjsfContainerRegistry(
       arrayBuilder: (ctx) => DjsfArrayField(
-        arrayControl: ctx.control,
-        arraySchema: ctx.arraySchema,
-        arrayUiSchema: ctx.arrayUiSchema,
-        messages: ctx.messages,
-        transformErrors: ctx.transformErrors,
-        registry: ctx.fieldRegistry,
-        parentSchema: ctx.parentSchema,
-        fieldName: ctx.fieldName,
+        ctx: ctx,
+        onDelete: (index) {
+          ctx.control.removeAt(index);
+        },
       ),
     );

--- a/lib/src/containers/defaults.dart
+++ b/lib/src/containers/defaults.dart
@@ -1,0 +1,15 @@
+import 'package:dart_json_schema_form/src/containers/containers.dart';
+import 'package:dart_json_schema_form/src/containers/defaults/array_field.dart';
+
+DjsfContainerRegistry defaultContainerRegistry() => DjsfContainerRegistry(
+      arrayBuilder: (ctx) => DjsfArrayField(
+        arrayControl: ctx.control,
+        arraySchema: ctx.arraySchema,
+        arrayUiSchema: ctx.arrayUiSchema,
+        messages: ctx.messages,
+        transformErrors: ctx.transformErrors,
+        registry: ctx.fieldRegistry,
+        parentSchema: ctx.parentSchema,
+        fieldName: ctx.fieldName,
+      ),
+    );

--- a/lib/src/containers/defaults/array_field.dart
+++ b/lib/src/containers/defaults/array_field.dart
@@ -1,36 +1,40 @@
 // lib/src/renderers/array_field.dart
 
 import 'dart:async';
+
 import 'package:dart_json_schema_form/dart_json_schema_form.dart';
 import 'package:dart_json_schema_form/generated/l10n.dart' as l10n;
+import 'package:dart_json_schema_form/src/containers/containers.dart';
 import 'package:dart_json_schema_form/src/renderers/form_renderer.dart';
-import 'package:dart_json_schema_form/src/utils/shared_messages.dart';
-import 'package:dart_json_schema_form/src/utils/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
 class DjsfArrayField extends StatefulWidget {
   const DjsfArrayField({
-    required this.arrayControl,
-    required this.arraySchema,
-    required this.arrayUiSchema,
-    required this.registry,
-    required this.messages,
-    required this.parentSchema,
-    required this.fieldName,
+    required this.ctx,
+    required this.onDelete,
     super.key,
-    this.transformErrors,
   });
 
-  final FormArray arrayControl;
-  final JsonMap arraySchema;
-  final JsonMap arrayUiSchema;
-  final DjsfFieldRegistry registry;
-  final DjsfMessageBundle messages;
-  final TransformErrors? transformErrors;
+  final DjsfArrayContext ctx;
 
-  final JsonMap parentSchema;
-  final String fieldName;
+  FormArray get arrayControl => ctx.control;
+
+  JsonMap get arraySchema => ctx.arraySchema;
+
+  JsonMap get arrayUiSchema => ctx.arrayUiSchema;
+
+  DjsfFieldRegistry get registry => ctx.fieldRegistry;
+
+  DjsfMessageBundle get messages => ctx.messages;
+
+  TransformErrors? get transformErrors => ctx.transformErrors;
+
+  JsonMap get parentSchema => ctx.parentSchema;
+
+  String get fieldName => ctx.fieldName;
+
+  final ValueChanged<int> onDelete;
 
   @override
   State<DjsfArrayField> createState() => _DjsfArrayFieldState();
@@ -54,11 +58,6 @@ class _DjsfArrayFieldState extends State<DjsfArrayField> {
         widget.arrayControl.add(_newControlForItem(itemSchema));
       }
     }
-
-    // Escuchar cambios del array para reconstruir la UI
-    _sub = widget.arrayControl.valueChanges.listen((_) {
-      if (mounted) setState(() {});
-    });
   }
 
   @override
@@ -75,9 +74,14 @@ class _DjsfArrayFieldState extends State<DjsfArrayField> {
         ? Map<String, dynamic>.from(widget.arrayUiSchema['ui:options'] as Map)
         : const <String, dynamic>{};
 
-    final addable = uiOptions['addable'] != false;
-    final removable = uiOptions['removable'] != false;
-    final orderable = uiOptions['orderable'] != false; // hook futuro
+    /// If the [arraySchema['items']] is a List we don't support add or remove
+    /// as is a fixed length list.
+    final addable =
+        widget.arraySchema['items'] is! List && uiOptions['addable'] != false;
+    final removable =
+        widget.arraySchema['items'] is! List && uiOptions['removable'] != false;
+    final orderable =
+        widget.arraySchema['items'] is! List && uiOptions['orderable'] != false;
 
     final addText = (uiOptions['addButtonText'] as String?) ??
         l10n.S.of(context).arrayAddItem;
@@ -88,45 +92,62 @@ class _DjsfArrayFieldState extends State<DjsfArrayField> {
       children: [
         Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
         const SizedBox(height: 8),
-        ListView.builder(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          itemCount: widget.arrayControl.controls.length,
-          itemBuilder: (context, index) {
-            final itemSchema = _asMap(widget.arraySchema['items']);
-            final itemUi = _itemUiSchema(widget.arrayUiSchema);
-            final control = widget.arrayControl.controls[index];
+        StreamBuilder<List<AbstractControl>>(
+          stream: widget.arrayControl.collectionChanges,
+          builder: (context, snap) {
+            var list = snap.data ?? widget.arrayControl.controls;
+            return ListView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              itemCount: list.length,
+              itemBuilder: (context, index) {
+                final itemSchema = _asMap(widget.arraySchema['items']);
+                final itemUi = _itemUiSchema(widget.arrayUiSchema);
+                final control = list[index];
 
-            Widget itemChild;
-            if (control is FormGroup) {
-              // ítem objeto → sub-form
-              itemChild = _buildObjectItem(index, control, itemSchema, itemUi);
-            } else {
-              // ítem primitivo → un solo campo
-              itemChild =
-                  _buildPrimitiveItem(index, control, itemSchema, itemUi);
-            }
+                Widget itemChild;
+                if (control is FormGroup) {
+                  // sub formular
+                  itemChild =
+                      _buildObjectItem(index, control, itemSchema, itemUi);
+                } else {
+                  // single field
+                  itemChild = FormRenderer.buildWithRegistry(
+                    index.toString(),
+                    itemSchema,
+                    widget.registry,
+                    schema: widget.parentSchema,
+                    control: control,
+                    messages: widget.messages,
+                    transformErrors: widget.transformErrors,
+                  );
+                }
 
-            return Card(
-              margin: const EdgeInsets.only(bottom: 8),
-              child: Padding(
-                padding: const EdgeInsets.all(8),
-                child: Column(
-                  children: [
-                    itemChild,
-                    if (removable)
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: TextButton.icon(
-                          onPressed: () => widget.arrayControl.removeAt(index),
-                          icon: const Icon(Icons.delete_outline),
-                          label: Text(removeText),
-                        ),
-                      ),
-                    if (!orderable) const SizedBox.shrink(),
-                  ],
-                ),
-              ),
+                return Card(
+                  key: ObjectKey(control.hashCode),
+                  margin: const EdgeInsets.only(bottom: 8),
+                  child: Padding(
+                    padding: const EdgeInsets.all(8),
+                    child: Column(
+                      children: [
+                        itemChild,
+                        if (removable)
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: TextButton.icon(
+                              onPressed: () {
+                                widget.onDelete(index);
+                              },
+                              icon: const Icon(Icons.delete_outline),
+                              label: Text(removeText),
+                            ),
+                          ),
+                        if (!orderable) const SizedBox.shrink(),
+                      ],
+                    ),
+                  ),
+                );
+              },
             );
           },
         ),
@@ -135,110 +156,12 @@ class _DjsfArrayFieldState extends State<DjsfArrayField> {
             onPressed: () {
               final itemSchema = _asMap(widget.arraySchema['items']);
               widget.arrayControl.add(_newControlForItem(itemSchema));
-              // setState no es estrictamente necesario porque escuchamos valueChanges,
-              // pero no hace daño y da respuesta visual inmediata.
-              setState(() {});
             },
             icon: const Icon(Icons.add),
             label: Text(addText),
           ),
       ],
     );
-  }
-
-  // Render de item primitivo usando el registry
-  Widget _buildPrimitiveItem(
-    int index,
-    AbstractControl control,
-    JsonMap itemSchema,
-    JsonMap itemUi,
-  ) {
-    final type = (itemSchema['type'] as String?) ?? 'string';
-    final title = (itemSchema['title'] as String?) ?? 'Item $index';
-
-    final fakeCtx = DjsfFieldContext(
-      form: FormGroup({'_': control}),
-      schema: {
-        'properties': {'_': itemSchema},
-      },
-      uiSchema: {'_': itemUi},
-      path: '_',
-      propSchema: itemSchema,
-      messages: widget.messages,
-      transformErrors: widget.transformErrors,
-      type: 'array',
-    );
-
-    final ui = readUiFor(fakeCtx);
-    final decoration = InputDecoration(
-      labelText: title,
-      hintText: ui.hint,
-      helperText: ui.description ?? ui.helper,
-    );
-
-    final messages = messagesForField(fakeCtx, '_', itemSchema);
-
-    switch (type) {
-      case 'integer':
-        return ReactiveTextField<int>(
-          formControl: control as FormControl<int>,
-          decoration: decoration,
-          keyboardType: TextInputType.number,
-          validationMessages: messages,
-          onChanged: (c) {
-            if ((c.value == null) && ui.emptyValue != null) {
-              final v = ui.emptyValue;
-              if (v is int) {
-                c.updateValue(v, emitEvent: false);
-              } else if (v is num) {
-                c.updateValue(v.toInt(), emitEvent: false);
-              } else if (v is String) {
-                final parsed = int.tryParse(v);
-                if (parsed != null) c.updateValue(parsed, emitEvent: false);
-              }
-            }
-          },
-        );
-
-      case 'number':
-        return ReactiveTextField<num>(
-          formControl: control as FormControl<num>,
-          decoration: decoration,
-          keyboardType: const TextInputType.numberWithOptions(decimal: true),
-          validationMessages: messages,
-          onChanged: (c) {
-            if ((c.value == null) && ui.emptyValue != null) {
-              final v = ui.emptyValue;
-              if (v is num) {
-                c.updateValue(v, emitEvent: false);
-              } else if (v is String) {
-                final parsed = num.tryParse(v);
-                if (parsed != null) c.updateValue(parsed, emitEvent: false);
-              }
-            }
-          },
-        );
-
-      case 'string':
-      default:
-        return ReactiveTextField<String>(
-          formControl: control as FormControl<String>,
-          decoration: decoration,
-          autofocus: ui.autofocus,
-          keyboardType: ui.keyboardTypeForString(),
-          autofillHints: ui.autocomplete != null ? [ui.autocomplete!] : null,
-          obscureText: ui.isPassword,
-          minLines: ui.isTextarea ? 3 : 1,
-          maxLines: ui.isTextarea ? 6 : 1,
-          validationMessages: messages,
-          onChanged: (c) {
-            if ((c.value == null || c.value!.isEmpty) &&
-                ui.emptyValue != null) {
-              c.updateValue(ui.emptyValue as String?, emitEvent: false);
-            }
-          },
-        );
-    }
   }
 
   Widget _buildObjectItem(

--- a/lib/src/containers/defaults/array_field.dart
+++ b/lib/src/containers/defaults/array_field.dart
@@ -1,0 +1,314 @@
+// lib/src/renderers/array_field.dart
+
+import 'dart:async';
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/generated/l10n.dart' as l10n;
+import 'package:dart_json_schema_form/src/renderers/form_renderer.dart';
+import 'package:dart_json_schema_form/src/utils/shared_messages.dart';
+import 'package:dart_json_schema_form/src/utils/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+class DjsfArrayField extends StatefulWidget {
+  const DjsfArrayField({
+    required this.arrayControl,
+    required this.arraySchema,
+    required this.arrayUiSchema,
+    required this.registry,
+    required this.messages,
+    required this.parentSchema,
+    required this.fieldName,
+    super.key,
+    this.transformErrors,
+  });
+
+  final FormArray arrayControl;
+  final JsonMap arraySchema;
+  final JsonMap arrayUiSchema;
+  final DjsfFieldRegistry registry;
+  final DjsfMessageBundle messages;
+  final TransformErrors? transformErrors;
+
+  final JsonMap parentSchema;
+  final String fieldName;
+
+  @override
+  State<DjsfArrayField> createState() => _DjsfArrayFieldState();
+}
+
+class _DjsfArrayFieldState extends State<DjsfArrayField> {
+  StreamSubscription<dynamic>? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // Si minItems > 0 y el array está vacío, pre-crear ítems “en blanco”.
+    final minItems = widget.arraySchema['minItems'] is int
+        ? widget.arraySchema['minItems'] as int
+        : 0;
+
+    if (minItems > 0 && widget.arrayControl.controls.isEmpty) {
+      final itemSchema = _asMap(widget.arraySchema['items']);
+      for (var i = 0; i < minItems; i++) {
+        widget.arrayControl.add(_newControlForItem(itemSchema));
+      }
+    }
+
+    // Escuchar cambios del array para reconstruir la UI
+    _sub = widget.arrayControl.valueChanges.listen((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final title = (widget.arraySchema['title'] as String?) ?? widget.fieldName;
+
+    final uiOptions = (widget.arrayUiSchema['ui:options'] is Map)
+        ? Map<String, dynamic>.from(widget.arrayUiSchema['ui:options'] as Map)
+        : const <String, dynamic>{};
+
+    final addable = uiOptions['addable'] != false;
+    final removable = uiOptions['removable'] != false;
+    final orderable = uiOptions['orderable'] != false; // hook futuro
+
+    final addText = (uiOptions['addButtonText'] as String?) ??
+        l10n.S.of(context).arrayAddItem;
+    final removeText = l10n.S.of(context).arrayRemoveItem;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
+        const SizedBox(height: 8),
+        ListView.builder(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          itemCount: widget.arrayControl.controls.length,
+          itemBuilder: (context, index) {
+            final itemSchema = _asMap(widget.arraySchema['items']);
+            final itemUi = _itemUiSchema(widget.arrayUiSchema);
+            final control = widget.arrayControl.controls[index];
+
+            Widget itemChild;
+            if (control is FormGroup) {
+              // ítem objeto → sub-form
+              itemChild = _buildObjectItem(index, control, itemSchema, itemUi);
+            } else {
+              // ítem primitivo → un solo campo
+              itemChild =
+                  _buildPrimitiveItem(index, control, itemSchema, itemUi);
+            }
+
+            return Card(
+              margin: const EdgeInsets.only(bottom: 8),
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: Column(
+                  children: [
+                    itemChild,
+                    if (removable)
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: TextButton.icon(
+                          onPressed: () => widget.arrayControl.removeAt(index),
+                          icon: const Icon(Icons.delete_outline),
+                          label: Text(removeText),
+                        ),
+                      ),
+                    if (!orderable) const SizedBox.shrink(),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+        if (addable)
+          OutlinedButton.icon(
+            onPressed: () {
+              final itemSchema = _asMap(widget.arraySchema['items']);
+              widget.arrayControl.add(_newControlForItem(itemSchema));
+              // setState no es estrictamente necesario porque escuchamos valueChanges,
+              // pero no hace daño y da respuesta visual inmediata.
+              setState(() {});
+            },
+            icon: const Icon(Icons.add),
+            label: Text(addText),
+          ),
+      ],
+    );
+  }
+
+  // Render de item primitivo usando el registry
+  Widget _buildPrimitiveItem(
+    int index,
+    AbstractControl control,
+    JsonMap itemSchema,
+    JsonMap itemUi,
+  ) {
+    final type = (itemSchema['type'] as String?) ?? 'string';
+    final title = (itemSchema['title'] as String?) ?? 'Item $index';
+
+    final fakeCtx = DjsfFieldContext(
+      form: FormGroup({'_': control}),
+      schema: {
+        'properties': {'_': itemSchema},
+      },
+      uiSchema: {'_': itemUi},
+      path: '_',
+      propSchema: itemSchema,
+      messages: widget.messages,
+      transformErrors: widget.transformErrors,
+      type: 'array',
+    );
+
+    final ui = readUiFor(fakeCtx);
+    final decoration = InputDecoration(
+      labelText: title,
+      hintText: ui.hint,
+      helperText: ui.description ?? ui.helper,
+    );
+
+    final messages = messagesForField(fakeCtx, '_', itemSchema);
+
+    switch (type) {
+      case 'integer':
+        return ReactiveTextField<int>(
+          formControl: control as FormControl<int>,
+          decoration: decoration,
+          keyboardType: TextInputType.number,
+          validationMessages: messages,
+          onChanged: (c) {
+            if ((c.value == null) && ui.emptyValue != null) {
+              final v = ui.emptyValue;
+              if (v is int) {
+                c.updateValue(v, emitEvent: false);
+              } else if (v is num) {
+                c.updateValue(v.toInt(), emitEvent: false);
+              } else if (v is String) {
+                final parsed = int.tryParse(v);
+                if (parsed != null) c.updateValue(parsed, emitEvent: false);
+              }
+            }
+          },
+        );
+
+      case 'number':
+        return ReactiveTextField<num>(
+          formControl: control as FormControl<num>,
+          decoration: decoration,
+          keyboardType: const TextInputType.numberWithOptions(decimal: true),
+          validationMessages: messages,
+          onChanged: (c) {
+            if ((c.value == null) && ui.emptyValue != null) {
+              final v = ui.emptyValue;
+              if (v is num) {
+                c.updateValue(v, emitEvent: false);
+              } else if (v is String) {
+                final parsed = num.tryParse(v);
+                if (parsed != null) c.updateValue(parsed, emitEvent: false);
+              }
+            }
+          },
+        );
+
+      case 'string':
+      default:
+        return ReactiveTextField<String>(
+          formControl: control as FormControl<String>,
+          decoration: decoration,
+          autofocus: ui.autofocus,
+          keyboardType: ui.keyboardTypeForString(),
+          autofillHints: ui.autocomplete != null ? [ui.autocomplete!] : null,
+          obscureText: ui.isPassword,
+          minLines: ui.isTextarea ? 3 : 1,
+          maxLines: ui.isTextarea ? 6 : 1,
+          validationMessages: messages,
+          onChanged: (c) {
+            if ((c.value == null || c.value!.isEmpty) &&
+                ui.emptyValue != null) {
+              c.updateValue(ui.emptyValue as String?, emitEvent: false);
+            }
+          },
+        );
+    }
+  }
+
+  Widget _buildObjectItem(
+    int index,
+    FormGroup fg,
+    JsonMap itemSchema,
+    JsonMap itemUi,
+  ) {
+    final title = (itemSchema['title'] as String?) ?? 'Item #$index';
+    return FormRenderer(
+      form: fg,
+      schema: itemSchema,
+      uiSchema: itemUi,
+      messages: widget.messages,
+      transformErrors: widget.transformErrors,
+      fieldRegistry: widget.registry,
+      sectionTitle: title,
+    );
+  }
+
+  AbstractControl _newControlForItem(JsonMap itemSchema) {
+    final type = (itemSchema['type'] as String?) ?? 'string';
+    switch (type) {
+      case 'object':
+        {
+          // crear FormGroup según properties (sin valores iniciales)
+          final props = _asMap(itemSchema['properties']);
+          final req = (itemSchema['required'] is List)
+              ? List<String>.from(itemSchema['required'] as List)
+              : const <String>[];
+          final map = <String, AbstractControl>{};
+          props.forEach((k, v) {
+            final sch = _asMap(v);
+            final isReq = req.contains(k);
+            map[k] = _newControlForItem(sch);
+            if (isReq && map[k] is FormControl) {
+              (map[k] as FormControl).setValidators(
+                [...(map[k] as FormControl).validators, Validators.required],
+                autoValidate: false,
+              );
+            }
+          });
+          return FormGroup(map);
+        }
+
+      case 'integer':
+        return FormControl<int>();
+
+      case 'number':
+        return FormControl<num>();
+
+      case 'boolean':
+        return FormControl<bool>();
+
+      case 'string':
+      default:
+        return FormControl<String>();
+    }
+  }
+
+  JsonMap _itemUiSchema(JsonMap root) {
+    // uiSchema para los ítems de un array suele estar bajo "<field>.items"
+    final items = root['items'];
+    return (items is Map)
+        ? Map<String, dynamic>.from(items)
+        : const <String, dynamic>{};
+  }
+
+  static Map<String, dynamic> _asMap(dynamic v) {
+    if (v is Map) return Map<String, dynamic>.from(v);
+    return const <String, dynamic>{};
+  }
+}

--- a/lib/src/containers/registry.dart
+++ b/lib/src/containers/registry.dart
@@ -1,0 +1,13 @@
+import 'package:dart_json_schema_form/src/containers/context.dart';
+import 'package:flutter/widgets.dart';
+
+typedef DjsfArrayBuilder = Widget Function(DjsfArrayContext ctx);
+
+class DjsfContainerRegistry {
+  DjsfContainerRegistry({required this.arrayBuilder});
+
+  final DjsfArrayBuilder arrayBuilder;
+
+  DjsfContainerRegistry copyWith({DjsfArrayBuilder? arrayBuilder}) =>
+      DjsfContainerRegistry(arrayBuilder: arrayBuilder ?? this.arrayBuilder);
+}

--- a/lib/src/fields/context.dart
+++ b/lib/src/fields/context.dart
@@ -5,7 +5,7 @@ import 'package:dart_json_schema_form/src/types/types.dart';
 class DjsfFieldContext {
   DjsfFieldContext({
     required this.type,
-    required this.form,
+    required this.control,
     required this.schema,
     required this.path,
     required this.propSchema,
@@ -15,13 +15,11 @@ class DjsfFieldContext {
   });
 
   final String type;
-  final FormGroup form;
+  final AbstractControl<dynamic> control;
   final JsonMap schema;
   final JsonMap? uiSchema;
   final String path;
   final JsonMap propSchema;
   final DjsfMessageBundle messages;
   final TransformErrors? transformErrors;
-
-  AbstractControl get control => form.control(path);
 }

--- a/lib/src/fields/defaults.dart
+++ b/lib/src/fields/defaults.dart
@@ -2,39 +2,40 @@ import 'package:dart_json_schema_form/src/fields/defaults/number_field.dart';
 import 'package:dart_json_schema_form/src/fields/defaults/text_field.dart';
 import 'package:dart_json_schema_form/src/fields/defaults/textarea_field.dart';
 import 'package:dart_json_schema_form/src/fields/registry.dart';
+import 'package:reactive_forms/reactive_forms.dart';
 
 DjsfFieldRegistry defaultFieldRegistry() => DjsfFieldRegistry({
       'string': (ctx) => DjsfTextField<String>(
-            formControlName: ctx.path,
+            formControl: ctx.control as FormControl<String>,
             ctx: ctx,
           ),
       'text': (ctx) => DjsfTextField<String>(
-            formControlName: ctx.path,
+            formControl: ctx.control as FormControl<String>,
             ctx: ctx,
           ),
       'integer': (ctx) => DjsfNumberField<int>(
-            formControlName: ctx.path,
+            formControl: ctx.control as FormControl<int>,
             ctx: ctx,
           ),
       'number': (ctx) => DjsfNumberField<num>(
-            formControlName: ctx.path,
+            formControl: ctx.control as FormControl<num>,
             ctx: ctx,
           ),
       'password': (ctx) => DjsfTextField<String>(
-            formControlName: ctx.path,
+            formControl: ctx.control as FormControl<String>,
             ctx: ctx,
             obscureText: true,
           ),
       'textarea': (ctx) => DjsfTextAreaField(
-            formControlName: ctx.path,
+            formControl: ctx.control as FormControl<String>,
             ctx: ctx,
           ),
       'tel': (ctx) => DjsfTextField<String>(
-            formControlName: ctx.path,
+            formControl: ctx.control as FormControl<String>,
             ctx: ctx,
           ),
       'email': (ctx) => DjsfTextField<String>(
-            formControlName: ctx.path,
+            formControl: ctx.control as FormControl<String>,
             ctx: ctx,
           ),
     });

--- a/lib/src/fields/defaults/number_field.dart
+++ b/lib/src/fields/defaults/number_field.dart
@@ -11,7 +11,7 @@ class DjsfNumberField<T extends num> extends ReactiveFormField<T, T> {
 
   DjsfNumberField({
     required this.ctx,
-    required super.formControlName,
+    required super.formControl,
     super.key,
     this.obscureText = false,
     this.keyboardType,

--- a/lib/src/fields/defaults/text_field.dart
+++ b/lib/src/fields/defaults/text_field.dart
@@ -11,7 +11,7 @@ class DjsfTextField<T> extends ReactiveFormField<T, T> {
 
   DjsfTextField({
     required this.ctx,
-    required super.formControlName,
+    required super.formControl,
     super.key,
     this.obscureText = false,
     this.keyboardType,

--- a/lib/src/fields/defaults/textarea_field.dart
+++ b/lib/src/fields/defaults/textarea_field.dart
@@ -11,7 +11,7 @@ class DjsfTextAreaField extends ReactiveFormField<String, String> {
 
   DjsfTextAreaField({
     required this.ctx,
-    required super.formControlName,
+    required super.formControl,
     super.key,
     this.obscureText = false,
     this.keyboardType,

--- a/lib/src/parsers/schema_parser.dart
+++ b/lib/src/parsers/schema_parser.dart
@@ -80,7 +80,8 @@ class SchemaParser {
       children[name] = _buildControlFromSchema(
         propSchema: propSchema,
         isRequired: isReq,
-        initialValue: mapInit[name],
+        initialValue: mapInit[name] ??
+            _resolveInitialValue(name, propSchema, initialValue),
       );
     });
     return FormGroup(children);

--- a/lib/src/parsers/schema_parser.dart
+++ b/lib/src/parsers/schema_parser.dart
@@ -1,5 +1,5 @@
-import 'package:reactive_forms/reactive_forms.dart';
 import 'package:dart_json_schema_form/src/types/types.dart';
+import 'package:reactive_forms/reactive_forms.dart';
 
 /// Utility class that converts JSON Schema into a Reactive Forms FormGroup.
 class SchemaParser {
@@ -11,38 +11,162 @@ class SchemaParser {
     JsonMap schema, {
     JsonMap? formData,
   }) {
-    final rawProps = schema['properties'];
-
-    // Ensure properties exist and are valid
-    if (rawProps == null || rawProps is! Map || rawProps.isEmpty) {
-      return FormGroup({});
-    }
-
-    final properties = Map<String, dynamic>.from(rawProps);
-
-    // Collect required fields from root-level "required": [...]
+    final props = _asMap(schema['properties']);
     final requiredList = (schema['required'] is List)
         ? List<String>.from(schema['required'] as List)
         : const <String>[];
-    final requiredSet = requiredList.toSet();
-
     final controls = <String, AbstractControl>{};
 
-    for (final entry in properties.entries) {
-      final name = entry.key;
-      final propSchema = _asMap(entry.value);
+    props.forEach((key, propSchemaDyn) {
+      final propSchema = _asMap(propSchemaDyn);
+      final isRequired = requiredList.contains(key);
+      final initial = _resolveInitialValue(key, propSchema, formData);
 
-      final initialValue = _resolveInitialValue(name, propSchema, formData);
-
-      final validators = _buildValidators(
-        propSchema,
-        isRequired: requiredSet.contains(name),
+      controls[key] = _buildControlFromSchema(
+        propSchema: propSchema,
+        isRequired: isRequired,
+        initialValue: initial,
       );
-
-      controls[name] = _buildTypedControl(propSchema, initialValue, validators);
-    }
+    });
 
     return FormGroup(controls);
+  }
+
+  static AbstractControl _buildControlFromSchema({
+    required JsonMap propSchema,
+    required bool isRequired,
+    dynamic initialValue,
+  }) {
+    final type = (propSchema['type'] as String?) ?? 'string';
+
+    switch (type) {
+      case 'object':
+        return _buildGroupForObject(propSchema, initialValue);
+
+      case 'array':
+        return _buildArrayForItems(propSchema, initialValue);
+
+      case 'integer':
+        return _buildLeafControl<int>(propSchema, isRequired, initialValue);
+      case 'number':
+        return _buildLeafControl<double>(propSchema, isRequired, initialValue);
+      case 'boolean':
+        return _buildLeafControl<bool>(propSchema, isRequired, initialValue);
+      default:
+        return _buildLeafControl<String>(
+          propSchema,
+          isRequired,
+          initialValue?.toString(),
+        );
+    }
+  }
+
+  static FormGroup _buildGroupForObject(
+    JsonMap objectSchema,
+    dynamic initialValue,
+  ) {
+    final props = _asMap(objectSchema['properties']);
+    final requiredList = (objectSchema['required'] is List)
+        ? List<String>.from(objectSchema['required'] as List)
+        : const <String>[];
+    final mapInit = (initialValue is Map)
+        ? Map<String, dynamic>.from(initialValue)
+        : const <String, dynamic>{};
+
+    final children = <String, AbstractControl>{};
+    props.forEach((name, sch) {
+      final propSchema = _asMap(sch);
+      final isReq = requiredList.contains(name);
+      children[name] = _buildControlFromSchema(
+        propSchema: propSchema,
+        isRequired: isReq,
+        initialValue: mapInit[name],
+      );
+    });
+    return FormGroup(children);
+  }
+
+  static FormArray _buildArrayForItems(
+    JsonMap arraySchema,
+    dynamic initialValue,
+  ) {
+    final itemsSchema = _asMap(
+      arraySchema['items'],
+    );
+
+    final listInit = (initialValue is List)
+        ? List<dynamic>.from(initialValue)
+        : const <dynamic>[];
+    final controls = <AbstractControl>[];
+
+    for (var i = 0; i < listInit.length; i++) {
+      controls.add(
+        _buildControlFromSchema(
+          propSchema: itemsSchema,
+          isRequired: false,
+          initialValue: listInit[i],
+        ),
+      );
+    }
+
+    final validators = <Validator<dynamic>>[];
+    if (arraySchema['minItems'] is int) {
+      final min = arraySchema['minItems'] as int;
+      validators.add(
+        DelegateValidator((control) {
+          final v = control.value as List?;
+          if (v == null) {
+            return {
+              'minItems': {'min': min},
+            };
+          }
+          return v.length >= min
+              ? null
+              : {
+                  'minItems': {'min': min},
+                };
+        }),
+      );
+    }
+    if (arraySchema['maxItems'] is int) {
+      final max = arraySchema['maxItems'] as int;
+      validators.add(
+        DelegateValidator((control) {
+          final v = control.value as List?;
+          if (v == null) return null; // vacío no viola max
+          return v.length <= max
+              ? null
+              : {
+                  'maxItems': {'max': max},
+                };
+        }),
+      );
+    }
+    if (arraySchema['uniqueItems'] == true) {
+      validators.add(
+        DelegateValidator((control) {
+          final v = control.value as List?;
+          if (v == null) return null;
+          final set = v.map((e) => e.toString()).toSet();
+          return set.length == v.length ? null : {'uniqueItems': true};
+        }),
+      );
+    }
+
+    return FormArray(controls, validators: validators);
+  }
+
+  static AbstractControl _buildLeafControl<T>(
+    JsonMap schema,
+    bool isRequired,
+    T? initialValue,
+  ) {
+    final validators = _buildValidators(
+      schema,
+      isRequired: isRequired,
+    );
+
+    return _buildTypedControl(schema, initialValue, validators);
   }
 
   /// Resolve initial value by priority: formData > schema.default > null.
@@ -139,10 +263,6 @@ class SchemaParser {
           value: value is bool ? value : null,
           validators: validators,
         );
-      case 'object':
-        return FormGroup({});
-      case 'array':
-        return FormArray([]);
       default:
         // Fallback to string
         return FormControl<String>(
@@ -152,8 +272,8 @@ class SchemaParser {
     }
   }
 
-  static JsonMap _asMap(dynamic v) {
+  static Map<String, dynamic> _asMap(dynamic v) {
     if (v is Map) return Map<String, dynamic>.from(v);
-    return <String, dynamic>{};
+    return const <String, dynamic>{};
   }
 }

--- a/lib/src/parsers/schema_parser.dart
+++ b/lib/src/parsers/schema_parser.dart
@@ -91,21 +91,36 @@ class SchemaParser {
     JsonMap arraySchema,
     dynamic initialValue,
   ) {
-    final itemsSchema = _asMap(
-      arraySchema['items'],
-    );
+    final itemsSchema = arraySchema['items'] is List
+        ? (arraySchema['items'] as List).map((e) => _asMap(e)).toList()
+        : _asMap(arraySchema['items']);
 
     final listInit = (initialValue is List)
         ? List<dynamic>.from(initialValue)
         : const <dynamic>[];
+
     final controls = <AbstractControl>[];
+    String? type;
 
     for (var i = 0; i < listInit.length; i++) {
+      final type0 = (itemsSchema is List)
+          ? itemsSchema[i]['type']
+          : (itemsSchema is Map)
+              ? itemsSchema['type']
+              : null;
+
+      type ??= type0;
+
+      assert(
+        type == type0 || type0 == 'dynamic',
+        'All items must have the same type.',
+      );
+
       controls.add(
         _buildControlFromSchema(
-          propSchema: itemsSchema,
+          propSchema: (itemsSchema is List) ? itemsSchema[i] : itemsSchema,
           isRequired: false,
-          initialValue: listInit[i],
+          initialValue: listInit.length > i ? listInit[i] : null,
         ),
       );
     }
@@ -154,7 +169,41 @@ class SchemaParser {
       );
     }
 
-    return FormArray(controls, validators: validators);
+    return createFormArray(controls, type, validators: validators);
+  }
+
+  static FormArray createFormArray(
+    List<AbstractControl> controls,
+    String? type, {
+    List<Validator<dynamic>>? validators,
+  }) {
+    return switch (type?.toLowerCase()) {
+      'int' => FormArray<int>(
+          controls as List<AbstractControl<int>>,
+          validators: validators ?? [],
+        ),
+      'double' => FormArray<double>(
+          controls as List<AbstractControl<double>>,
+          validators: validators ?? [],
+        ),
+      'bool' => FormArray<bool>(
+          controls as List<AbstractControl<bool>>,
+          validators: validators ?? [],
+        ),
+      'String' => FormArray<String>(
+          controls as List<AbstractControl<String>>,
+          validators: validators ?? [],
+        ),
+      'array' => FormArray(
+          controls,
+          validators: validators ?? [],
+        ),
+      'object' => FormArray(
+          controls,
+          validators: validators ?? [],
+        ),
+      _ => FormArray<dynamic>(controls, validators: validators ?? []),
+    };
   }
 
   static AbstractControl _buildLeafControl<T>(
@@ -181,6 +230,25 @@ class SchemaParser {
     }
     if (propSchema.containsKey('default')) {
       return propSchema['default'];
+    }
+
+    if (propSchema.containsKey('items')) {
+      final items = propSchema['items'];
+      if (items is List) {
+        return List<dynamic>.generate(items.length, (index) {
+          if (items[index] is Map) {
+            return _asMap(items[index])['default'];
+          }
+          return null;
+        });
+      }
+      if (items is Map) {
+        final defa = _asMap(items)['default'];
+        if (defa is List) {
+          return defa;
+        }
+        return defa != null ? [defa] : null;
+      }
     }
     return null;
   }

--- a/lib/src/renderers/form_renderer.dart
+++ b/lib/src/renderers/form_renderer.dart
@@ -1,5 +1,3 @@
-import 'dart:convert';
-
 import 'package:dart_json_schema_form/dart_json_schema_form.dart';
 import 'package:dart_json_schema_form/src/containers/containers.dart';
 import 'package:dart_json_schema_form/src/fields/defaults.dart';
@@ -98,10 +96,15 @@ class FormRenderer extends StatelessWidget {
       }
 
       children.add(
-        _buildWithRegistry(
+        buildWithRegistry(
           name,
           propSchema,
           fields,
+          schema: schema,
+          control: form.control(name),
+          uiSchema: uiSchema,
+          messages: messages,
+          transformErrors: transformErrors,
         ),
       );
     }
@@ -111,22 +114,24 @@ class FormRenderer extends StatelessWidget {
     );
   }
 
-  Widget _buildWithRegistry(
+  static Widget buildWithRegistry(
     String name,
     JsonMap propSchema,
-    DjsfFieldRegistry registry,
-  ) {
+    DjsfFieldRegistry registry, {
+    required JsonMap schema,
+    required AbstractControl<dynamic> control,
+    JsonMap? uiSchema,
+    DjsfMessageBundle messages = const IntlBundle(),
+    TransformErrors? transformErrors,
+  }) {
     final type = (propSchema['type'] as String?) ?? 'string';
     final ui = uiSchema?[name] as JsonMap? ?? {};
     final modifier = (ui['ui:options'] as JsonMap?)?['inputType'] as String?;
     final widgetKey = modifier ?? (ui['ui:widget'] as String?) ?? type;
 
-    debugPrint("Building $name with type $type and widgetKey $widgetKey");
-    debugPrint("Building with uiSchema: ${jsonEncode(ui)}");
-
     final ctx = DjsfFieldContext(
       type: widgetKey,
-      form: form,
+      control: control,
       schema: schema,
       uiSchema: uiSchema,
       path: name,

--- a/lib/src/renderers/form_renderer.dart
+++ b/lib/src/renderers/form_renderer.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/src/containers/containers.dart';
 import 'package:dart_json_schema_form/src/fields/defaults.dart';
 import 'package:dart_json_schema_form/src/i18n/bundles.dart';
 import 'package:flutter/material.dart';
@@ -16,6 +17,8 @@ class FormRenderer extends StatelessWidget {
     this.messages = const IntlBundle(),
     this.transformErrors,
     this.fieldRegistry,
+    this.containerRegistry,
+    this.sectionTitle,
   });
 
   final FormGroup form;
@@ -24,6 +27,8 @@ class FormRenderer extends StatelessWidget {
   final DjsfMessageBundle messages;
   final TransformErrors? transformErrors;
   final DjsfFieldRegistry? fieldRegistry;
+  final DjsfContainerRegistry? containerRegistry; // NEW
+  final String? sectionTitle;
 
   @override
   Widget build(BuildContext context) {
@@ -31,15 +36,78 @@ class FormRenderer extends StatelessWidget {
     if (rawProps == null || rawProps is! Map || rawProps.isEmpty) {
       return const SizedBox.shrink();
     }
-    final properties = Map<String, dynamic>.from(rawProps);
-    final registry = fieldRegistry ?? defaultFieldRegistry();
 
+    final properties = Map<String, dynamic>.from(rawProps);
+    final fields = fieldRegistry ?? defaultFieldRegistry();
+    final containers = containerRegistry ?? defaultContainerRegistry(); // NEW
+
+    final children = <Widget>[
+      if (sectionTitle != null) ...[
+        Padding(
+          padding: const EdgeInsets.only(top: 8, bottom: 4),
+          child: Text(
+            sectionTitle!,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+        ),
+        const Divider(height: 16),
+      ],
+    ];
+
+    for (final entry in form.controls.entries) {
+      final name = entry.key;
+      final control = entry.value;
+      final propSchema = properties[name] as JsonMap? ?? {};
+      final fieldUi = (uiSchema?[name] as JsonMap?) ?? const {};
+
+      if (control is FormGroup) {
+        // nested object → recurse
+        final title = (propSchema['title'] as String?) ?? name;
+        children.add(
+          FormRenderer(
+            form: control,
+            schema: propSchema,
+            uiSchema: (fieldUi['items'] is Map) // si vino desde arrays
+                ? Map<String, dynamic>.from(fieldUi['items'] as Map)
+                : fieldUi,
+            messages: messages,
+            transformErrors: transformErrors,
+            fieldRegistry: fields,
+            containerRegistry: containers,
+            // keep passing it down
+            sectionTitle: title,
+          ),
+        );
+        continue;
+      }
+
+      if (control is FormArray) {
+        // ARRAY → delega al containerRegistry
+        final ctx = DjsfArrayContext(
+          control: control,
+          arraySchema: propSchema,
+          arrayUiSchema: fieldUi,
+          messages: messages,
+          transformErrors: transformErrors,
+          fieldRegistry: fields,
+          fieldName: name,
+          parentSchema: schema,
+        );
+        children.add(containers.arrayBuilder(ctx));
+        continue;
+      }
+
+      children.add(
+        _buildWithRegistry(
+          name,
+          propSchema,
+          fields,
+        ),
+      );
+    }
     return Column(
-      children: form.controls.entries.map((entry) {
-        final name = entry.key;
-        final propSchema = properties[name] as JsonMap? ?? {};
-        return _buildWithRegistry(name, propSchema, registry);
-      }).toList(),
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: children,
     );
   }
 

--- a/test/fields/djsf_array_field_test.dart
+++ b/test/fields/djsf_array_field_test.dart
@@ -1,0 +1,48 @@
+import 'package:dart_json_schema_form/dart_json_schema_form.dart';
+import 'package:dart_json_schema_form/generated/l10n.dart' as djsf_l10n;
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('array of strings shows inputs and Add works', (tester) async {
+    final schema = {
+      "title": "Tags",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "title": "Tags",
+          "items": {"type": "string", "title": "Tag"},
+          "minItems": 1,
+        },
+      },
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: const [
+          djsf_l10n.S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: Scaffold(
+          body: DjsfForm(
+            schema: schema,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TextField), findsWidgets);
+
+    await tester.tap(find.text('Add item'));
+    await tester.pumpAndSettle();
+
+    final count = tester.widgetList<TextField>(find.byType(TextField)).length;
+    expect(count, greaterThanOrEqualTo(2));
+  });
+}

--- a/test/fields/djsf_array_field_test.dart
+++ b/test/fields/djsf_array_field_test.dart
@@ -37,12 +37,152 @@ void main() {
 
     await tester.pumpAndSettle();
 
-    expect(find.byType(TextField), findsWidgets);
+    expect(find.byType(TextField), findsOneWidget);
 
     await tester.tap(find.text('Add item'));
     await tester.pumpAndSettle();
 
-    final count = tester.widgetList<TextField>(find.byType(TextField)).length;
-    expect(count, greaterThanOrEqualTo(2));
+    expect(find.byType(TextField), findsNWidgets(2));
+  });
+
+  testWidgets('delete buttons remove item in index', (tester) async {
+    final schema = {
+      "title": "Tags",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "title": "Tags",
+          "items": {"type": "string", "title": "Tag"},
+          "minItems": 1,
+        },
+      },
+    };
+
+    final data = {
+      "tags": ["foo", "bar", "tar"],
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: const [
+          djsf_l10n.S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: Scaffold(
+          body: DjsfForm(
+            schema: schema,
+            formData: data,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TextField), findsNWidgets(3));
+
+    await tester.tap(find.text('Remove').first);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TextField), findsNWidgets(2));
+  });
+
+  testWidgets('Can not add or remove items in fixed array list',
+      (tester) async {
+    final schema = {
+      "title": "Tags",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "title": "Tags",
+          "items": [
+            {"type": "string", "title": "Tag", "default": "foo"},
+            {"type": "string", "title": "Tag", "default": "bar"},
+          ],
+        },
+      },
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: const [
+          djsf_l10n.S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: Scaffold(
+          body: DjsfForm(
+            schema: schema,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TextField), findsNWidgets(2));
+
+    expect(find.text('Add item'), findsNothing);
+    expect(find.text('Remove'), findsNothing);
+  });
+
+  testWidgets('array of objects shows inputs and Add works', (tester) async {
+    final schema = {
+      "title": "Tags",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "title": "Tags",
+          "items": {
+            "type": "object",
+            "title": "Tag",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "default": "foo",
+              },
+              "age": {
+                "type": "integer",
+                "title": "Age",
+                "default": "10",
+              },
+            },
+          },
+          "minItems": 1,
+        },
+      },
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: const [
+          djsf_l10n.S.delegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate,
+          GlobalCupertinoLocalizations.delegate,
+        ],
+        home: Scaffold(
+          body: DjsfForm(
+            schema: schema,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TextField), findsNWidgets(2));
+
+    await tester.tap(find.text('Add item'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(TextField), findsNWidgets(4));
   });
 }

--- a/test/parsers/schema_parser_test.dart
+++ b/test/parsers/schema_parser_test.dart
@@ -110,4 +110,349 @@ void main() {
       expect(form.control('nickname').value, isNull);
     });
   });
+
+  group('SchemaParser nested objects', () {
+    test('parses nested objects correctly', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "level1": {
+            "type": "object",
+            "properties": {
+              "level2text": {"type": "string"},
+              "level2obj": {
+                "type": "object",
+                "properties": {
+                  "level3bool": {"type": "boolean"},
+                },
+              },
+            },
+          },
+        },
+      };
+
+      final formData = {
+        "level1": {
+          "level2text": "hello",
+          "level2obj": {
+            "level3bool": true,
+          },
+        },
+      };
+
+      final form = SchemaParser.buildFormGroup(schema, formData: formData);
+
+      expect(form.control('level1'), isA<FormGroup>());
+      final level1Group = form.control('level1') as FormGroup;
+
+      expect(level1Group.control('level2text'), isA<FormControl<String>>());
+      expect(level1Group.control('level2text').value, "hello");
+
+      expect(level1Group.control('level2obj'), isA<FormGroup>());
+      final level2ObjGroup = level1Group.control('level2obj') as FormGroup;
+
+      expect(level2ObjGroup.control('level3bool'), isA<FormControl<bool>>());
+      expect(level2ObjGroup.control('level3bool').value, true);
+    });
+
+    test('creates nested FormGroup with internal required and defaults', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "profile": {
+            "type": "object",
+            "required": ["city"],
+            "properties": {
+              "firstName": {"type": "string", "default": "Alice"},
+              "city": {"type": "string"},
+              "age": {"type": "integer", "default": 30},
+            },
+          },
+        },
+      };
+
+      final form = SchemaParser.buildFormGroup(schema);
+      final profile = form.control('profile');
+
+      expect(profile, isA<FormGroup>());
+      final fg = profile as FormGroup;
+
+      // internal required: 'city' should start invalid
+      final city = fg.control('city') as FormControl<String>;
+      expect(city.invalid, isTrue);
+      expect(city.hasError(ValidationMessage.required), isTrue);
+
+      // defaults
+      expect((fg.control('firstName') as FormControl<String>).value, 'Alice');
+      expect((fg.control('age') as FormControl<int>).value, 30);
+
+      // fix city
+      city.value = 'London';
+      expect(fg.valid, isTrue);
+    });
+
+    test('initial formData overrides defaults within nested object', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "profile": {
+            "type": "object",
+            "properties": {
+              "firstName": {"type": "string", "default": "Alice"},
+              "age": {"type": "integer", "default": 30},
+            },
+          },
+        },
+      };
+
+      final form = SchemaParser.buildFormGroup(
+        schema,
+        formData: {
+          "profile": {"firstName": "Bob"},
+        },
+      );
+
+      final fg = form.control('profile') as FormGroup;
+      expect((fg.control('firstName') as FormControl<String>).value, 'Bob');
+      expect(
+        (fg.control('age') as FormControl<int>).value,
+        30,
+      ); // untouched default
+    });
+  });
+
+  group('SchemaParser array parsing', () {
+    test('parses array of simple types with initialData', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+          },
+        },
+      };
+      final formData = {
+        "tags": ["dart", "flutter"],
+      };
+      final form = SchemaParser.buildFormGroup(schema, formData: formData);
+      expect(form.control('tags'), isA<FormArray>());
+      final tagsArray = form.control('tags') as FormArray;
+      expect(tagsArray.controls.length, 2);
+      expect(tagsArray.control('0').value, "dart");
+      expect(tagsArray.control('1').value, "flutter");
+    });
+
+    test('parses array of objects with initialData', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "users": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {"type": "string"},
+                "age": {"type": "integer"},
+              },
+            },
+          },
+        },
+      };
+      final formData = {
+        "users": [
+          {"name": "Alice", "age": 30},
+          {"name": "Bob", "age": 25},
+        ],
+      };
+      final form = SchemaParser.buildFormGroup(schema, formData: formData);
+      expect(form.control('users'), isA<FormArray>());
+      final usersArray = form.control('users') as FormArray;
+      expect(usersArray.controls.length, 2);
+      expect(usersArray.control('0'), isA<FormGroup>());
+      expect(
+        (usersArray.control('0') as FormGroup).control('name').value,
+        "Alice",
+      );
+      expect((usersArray.control('0') as FormGroup).control('age').value, 30);
+      expect(
+        (usersArray.control('1') as FormGroup).control('name').value,
+        "Bob",
+      );
+      expect((usersArray.control('1') as FormGroup).control('age').value, 25);
+    });
+
+    test('parses array with default values from schema', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "colors": {
+            "type": "array",
+            "items": {"type": "string"},
+            "default": ["red", "green"],
+          },
+        },
+      };
+      final form = SchemaParser.buildFormGroup(schema);
+      expect(form.control('colors'), isA<FormArray>());
+      final colorsArray = form.control('colors') as FormArray;
+      expect(colorsArray.controls.length, 2);
+      expect(colorsArray.control('0').value, "red");
+      expect(colorsArray.control('1').value, "green");
+    });
+
+    test('parses empty array when no initialData or default', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "tasks": {
+            "type": "array",
+            "items": {"type": "string"},
+          },
+        },
+      };
+      final form = SchemaParser.buildFormGroup(schema);
+      expect(form.control('tasks'), isA<FormArray>());
+      final tasksArray = form.control('tasks') as FormArray;
+      expect(tasksArray.controls.isEmpty, true);
+    });
+  });
+
+  group('SchemaParser array of objects', () {
+    test('creates FormArray of FormGroup items with required inside items', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "addresses": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["city"],
+              "properties": {
+                "street": {"type": "string"},
+                "city": {"type": "string"},
+                "zip": {"type": "string"},
+              },
+            },
+          },
+        },
+      };
+
+      final form = SchemaParser.buildFormGroup(
+        schema,
+        formData: {
+          "addresses": [
+            {"street": "Main 1", "zip": "12345"}, // missing city
+            {"street": "Main 2", "city": "Berlin", "zip": "10115"},
+          ],
+        },
+      );
+
+      final arr = form.control('addresses') as FormArray;
+      expect(arr.controls, hasLength(2));
+      expect(arr.controls.first, isA<FormGroup>());
+      expect(arr.controls.last, isA<FormGroup>());
+
+      final first = arr.controls.first as FormGroup;
+      final last = arr.controls.last as FormGroup;
+
+      // first is invalid due to required city
+      final firstCity = first.control('city') as FormControl<String>;
+      expect(firstCity.invalid, isTrue);
+      expect(firstCity.hasError(ValidationMessage.required), isTrue);
+
+      // second should be valid (city present)
+      expect((last.control('city') as FormControl<String>).value, 'Berlin');
+    });
+
+    test(
+        'defaults inside item schema are applied if not overridden by formData',
+        () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "addresses": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "country": {"type": "string", "default": "DE"},
+                "city": {"type": "string"},
+              },
+            },
+          },
+        },
+      };
+
+      final form = SchemaParser.buildFormGroup(
+        schema,
+        formData: {
+          "addresses": [
+            {"city": "Hamburg"},
+            {"country": "FR", "city": "Paris"},
+          ],
+        },
+      );
+
+      final arr = form.control('addresses') as FormArray;
+      final first = arr.controls.first as FormGroup;
+      final second = arr.controls.last as FormGroup;
+
+      expect(
+        (first.control('country') as FormControl<String>).value,
+        'DE',
+      ); // default applied
+      expect(
+        (second.control('country') as FormControl<String>).value,
+        'FR',
+      ); // overridden
+    });
+  });
+
+  group('SchemaParser initial value precedence', () {
+    test('formData > default (primitive, object, array)', () {
+      final schema = {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string", "default": "Alice"},
+          "profile": {
+            "type": "object",
+            "properties": {
+              "age": {"type": "integer", "default": 30},
+              "city": {"type": "string", "default": "London"},
+            },
+          },
+          "tags": {
+            "type": "array",
+            "items": {"type": "string"},
+          },
+        },
+      };
+
+      final form = SchemaParser.buildFormGroup(
+        schema,
+        formData: {
+          "name": "Bob", // overrides default
+          "profile": {"city": "Berlin"}, // overrides just city
+          "tags": ["x", "y"],
+        },
+      );
+
+      expect((form.control('name') as FormControl<String>).value, 'Bob');
+
+      final profile = form.control('profile') as FormGroup;
+      expect(
+        (profile.control('age') as FormControl<int>).value,
+        30,
+      ); // default remains
+      expect(
+        (profile.control('city') as FormControl<String>).value,
+        'Berlin',
+      ); // overridden
+
+      final tags = form.control('tags') as FormArray;
+      expect(tags.controls.length, 2);
+      expect((tags.controls[1] as FormControl<String>).value, 'y');
+    });
+  });
 }

--- a/test/parsers/schema_parser_validators_test.dart
+++ b/test/parsers/schema_parser_validators_test.dart
@@ -1,6 +1,6 @@
+import 'package:dart_json_schema_form/src/parsers/schema_parser.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reactive_forms/reactive_forms.dart';
-import 'package:dart_json_schema_form/src/parsers/schema_parser.dart';
 
 void main() {
   group('SchemaParser validators', () {
@@ -194,6 +194,266 @@ void main() {
       expect(c.hasError(ValidationMessage.required), isTrue);
       c.value = false; // present but false
       expect(c.hasError(ValidationMessage.required), isFalse);
+    });
+
+    group('SchemaParser array validators', () {
+      test('minItems validator for array', () {
+        final schema = {
+          "type": "object",
+          "properties": {
+            "tags": {
+              "type": "array",
+              "items": {"type": "string"},
+              "minItems": 2,
+            },
+          },
+        };
+
+        // Test with initial data
+        var form = SchemaParser.buildFormGroup(
+          schema,
+          formData: {
+            "tags": ["one"],
+          },
+        );
+        var control = form.control('tags') as FormArray;
+        expect(
+          control.hasError('minItems'),
+          isTrue,
+          reason: "Should fail if items < minItems with initialData",
+        );
+
+        form = SchemaParser.buildFormGroup(
+          schema,
+          formData: {
+            "tags": ["one", "two"],
+          },
+        );
+        control = form.control('tags') as FormArray;
+        expect(
+          control.valid,
+          isTrue,
+          reason: "Should be valid if items == minItems with initialData",
+        );
+
+        // Test by manipulating the FormArray
+        form = SchemaParser.buildFormGroup(schema);
+        control = form.control('tags') as FormArray;
+
+        control.add(FormControl<String>(value: 'apple'));
+        // At this point, the FormArray itself might not automatically re-validate based on item changes
+        // for minItems/maxItems. ReactiveForms usually validates on value changes or status changes.
+        // Explicitly marking as touched or manually calling updateValueAndValidity might be needed
+        // depending on how validation is triggered in the actual application.
+        // For testing schema parsing to AbstractControl, we check the validator directly.
+        expect(
+          control.validators.isNotEmpty,
+          isTrue,
+          reason: "Control should have a validator.",
+        );
+        final errors = control.errors;
+        expect(
+          errors['minItems'],
+          isNotNull,
+          reason:
+              "Should have minItems error when programmatically underpopulated",
+        );
+
+        control.add(FormControl<String>(value: 'banana'));
+        final noErrors = control.errors;
+        expect(
+          noErrors['minItems'],
+          isNull,
+          reason:
+              "Should not have minItems error when programmatically populated to minItems",
+        );
+        // After items are added to meet minItems, the control should become valid.
+        // Depending on ReactiveForms' internal behavior, a manual re-validation might be implicitly triggered or you might need to call it.
+        // For this test, assuming re-validation happens or .valid reflects the latest state after validator check:
+        control.updateValueAndValidity(); // Ensure re-validation
+        expect(
+          control.valid,
+          isTrue,
+          reason:
+              "Control should be valid after meeting minItems and revalidating",
+        );
+      });
+
+      test('maxItems validator for array', () {
+        final schema = {
+          "type": "object",
+          "properties": {
+            "categories": {
+              "type": "array",
+              "items": {"type": "integer"},
+              "maxItems": 3,
+            },
+          },
+        };
+
+        // Test with initial data
+        var form = SchemaParser.buildFormGroup(
+          schema,
+          formData: {
+            "categories": [1, 2, 3, 4],
+          },
+        );
+        var control = form.control('categories') as FormArray;
+        expect(
+          control.hasError("maxItems"),
+          isTrue,
+          reason: "Should fail if items > maxItems with initialData",
+        );
+
+        form = SchemaParser.buildFormGroup(
+          schema,
+          formData: {
+            "categories": [1, 2, 3],
+          },
+        );
+        control = form.control('categories') as FormArray;
+        expect(
+          control.valid,
+          isTrue,
+          reason: "Should be valid if items == maxItems with initialData",
+        );
+
+        // Test by manipulating the FormArray
+        form = SchemaParser.buildFormGroup(
+          schema,
+          formData: {
+            "categories": [10, 20],
+          },
+        ); // Start with a valid number of items
+        control = form.control('categories') as FormArray;
+        expect(
+          control.valid,
+          isTrue,
+          reason: "Control should initially be valid",
+        );
+
+        control.add(FormControl<int>(value: 30)); // Now 3 items, at maxItems
+        // control.updateValueAndValidity(); // Ensure re-validation
+        final noErrors = control.errors;
+        expect(
+          noErrors["maxItems"],
+          isNull,
+          reason: "Should not have maxItems error when at maxItems",
+        );
+        control.updateValueAndValidity();
+        expect(
+          control.valid,
+          isTrue,
+          reason: "Control should be valid at maxItems",
+        );
+
+        control.add(
+          FormControl<int>(value: 40),
+        ); // Now 4 items, exceeding maxItems
+        final errors = control.errors;
+        expect(
+          errors["maxItems"],
+          isNotNull,
+          reason:
+              "Should have maxItems error when programmatically overpopulated",
+        );
+        control.updateValueAndValidity();
+        expect(
+          control.invalid,
+          isTrue,
+          reason:
+              "Control should be invalid after exceeding maxItems and revalidating",
+        );
+      });
+
+      test('uniqueItems validator for array', () {
+        final schema = {
+          "type": "object",
+          "properties": {
+            "keywords": {
+              "type": "array",
+              "items": {"type": "string"},
+              "uniqueItems": true,
+            },
+          },
+        };
+
+        // Test with initial data
+        var form = SchemaParser.buildFormGroup(
+          schema,
+          formData: {
+            "keywords": ["a", "b", "a"],
+          },
+        );
+        var control = form.control('keywords') as FormArray;
+        expect(
+          control.hasError("uniqueItems"),
+          isTrue,
+          reason: "Should fail with duplicate items in initialData",
+        );
+
+        form = SchemaParser.buildFormGroup(
+          schema,
+          formData: {
+            "keywords": ["a", "b", "c"],
+          },
+        );
+        control = form.control('keywords') as FormArray;
+        expect(
+          control.valid,
+          isTrue,
+          reason: "Should be valid with unique items in initialData",
+        );
+
+        // Test by manipulating the FormArray
+        form = SchemaParser.buildFormGroup(
+          schema,
+          formData: {
+            "keywords": ["hello", "world"],
+          },
+        );
+        control = form.control('keywords') as FormArray;
+        expect(
+          control.valid,
+          isTrue,
+          reason: "Control should initially be valid",
+        );
+
+        control.add(FormControl<String>(value: 'hello')); // Add a duplicate
+        final errors = control.errors;
+        expect(
+          errors["uniqueItems"],
+          isNotNull,
+          reason: "Should have uniqueItems error after adding a duplicate",
+        );
+        control.updateValueAndValidity();
+        expect(
+          control.invalid,
+          isTrue,
+          reason:
+              "Control should be invalid after adding duplicate and revalidating",
+        );
+
+        // Remove the duplicate and test again
+        control
+            .removeAt(control.controls.length - 1); // remove the last 'hello'
+        control
+            .add(FormControl<String>(value: 'test')); // add a new unique item
+        final noErrors = control.errors;
+        expect(
+          noErrors["uniqueItems"],
+          isNull,
+          reason:
+              "Should not have uniqueItems error after removing duplicate and adding unique",
+        );
+        control.updateValueAndValidity();
+        expect(
+          control.valid,
+          isTrue,
+          reason:
+              "Control should be valid after fixing duplicates and revalidating",
+        );
+      });
     });
   });
 }

--- a/test/utils/shared_messages_test.dart
+++ b/test/utils/shared_messages_test.dart
@@ -36,7 +36,7 @@ void main() {
       };
       return DjsfFieldContext(
         type: 'string',
-        form: form,
+        control: form.control('f'),
         schema: schema,
         uiSchema: const {},
         path: 'f',

--- a/test/utils/ui_utils_test.dart
+++ b/test/utils/ui_utils_test.dart
@@ -35,7 +35,7 @@ void main() {
 
       final ctx = DjsfFieldContext(
         type: 'email',
-        form: form,
+        control: form.control('email'),
         schema: schema,
         uiSchema: uiSchema,
         path: 'email',
@@ -80,7 +80,7 @@ void main() {
 
       final ctx = DjsfFieldContext(
         type: 'password',
-        form: form,
+        control: form.control('pwd'),
         schema: schema,
         uiSchema: uiSchema,
         path: 'pwd',
@@ -115,7 +115,7 @@ void main() {
 
       final ctx = DjsfFieldContext(
         type: 'textarea',
-        form: form,
+        control: form.control('bio'),
         schema: schema,
         uiSchema: uiSchema,
         path: 'bio',
@@ -156,7 +156,7 @@ void main() {
 
       final ctx = DjsfFieldContext(
         type: 'string',
-        form: form,
+        control: form.control('name'),
         schema: schema,
         uiSchema: uiSchema,
         path: 'name',


### PR DESCRIPTION
### Overview

This PR extends the core functionality of `dart_json_schema_form` to support **arrays** and **nested objects**, bringing the library closer to full RJSF compatibility. It also introduces localized UI labels and a new container registry for extensibility.

---

### ✨ New Features

#### 1) Arrays

* Support for `type: array` schemas with:

    * `minItems`, `maxItems`, `uniqueItems` validators
    * Primitive item types (`string`, `integer`, `number`, `boolean`)
    * Object items rendered as sub-forms (`FormGroup` per item)
* Array-specific UI Schema options:

    * `ui:options.addButtonText` (custom add button label)
    * `ui:options.addable`, `removable`, `orderable`

#### 2) Nested Objects

* Support for `type: object` within properties or array items
* Internal `required` handling for nested fields
* `default` values applied recursively
* Precedence: `formData > default`

#### 3) Localized Array Labels

* New Intl keys (camelCase):

    * `arrayAddItem`
    * `arrayRemoveItem`
    * `arrayItemTitle`
* Integrated into existing `S` localization files (`intl_*.arb`)
* If `ui:options.addButtonText` is not provided, localized fallback text is used

#### 4) Container Registry

* Introduced `DjsfContainerRegistry`
* Allows overriding how arrays (and other container types in the future) are rendered
* Default implementation uses `DjsfArrayField`

---

### 🧪 Tests

* Added comprehensive unit tests for:

    * Array creation and typing
    * Validators (`minItems`, `maxItems`, `uniqueItems`)
    * Nested object defaults and required fields
    * Array of objects with nested required and defaults
    * Precedence of `formData` over `default` across primitives, objects, and arrays
* Ensures correct population of initial values and validator behavior

---

### 📚 Documentation

* Updated **README.md** with:

    * Arrays example
    * Nested objects example
    * Localized array labels
    * Container registry usage
* ARB files extended with new keys for all supported locales

---

### ✅ Checklist

* [x] Arrays supported with validators
* [x] Nested objects supported recursively
* [x] Localized UI labels integrated via Intl
* [x] Container registry added and documented
* [x] Unit tests extended for arrays and nesting
* [x] README updated with new usage examples